### PR TITLE
Generate legislative/index.json

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,13 +7,18 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     codecov (0.1.10)
       json
       simplecov
       url
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     docile (1.1.5)
     domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
+    hashdiff (0.3.7)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     json (2.1.0)
@@ -22,20 +27,27 @@ GEM
     mime-types-data (3.2016.0521)
     minitest (5.11.3)
     netrc (0.11.0)
+    public_suffix (3.0.2)
     rake (10.5.0)
     rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
+    safe_yaml (1.0.4)
     simplecov (0.15.1)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
+    timecop (0.9.1)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.4)
     url (0.3.2)
+    webmock (2.3.2)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
 
 PLATFORMS
   ruby
@@ -46,6 +58,8 @@ DEPENDENCIES
   commons-builder!
   minitest (~> 5.0)
   rake (~> 10.0)
+  timecop (~> 0.9.1)
+  webmock (~> 2.0)
 
 BUNDLED WITH
    1.16.1

--- a/bin/generate_legislative_index
+++ b/bin/generate_legislative_index
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+
+# frozen_string_literal: true
+require 'bundler/setup'
+require 'json'
+require 'commons/builder'
+
+
+config = Config.new("config.json").values
+LANGUAGE_MAP = config[:language_map]
+COUNTRY_WIKIDATA_ID = config[:country_wikidata_id]
+
+legislatures = Legislature.list(COUNTRY_WIKIDATA_ID, LANGUAGE_MAP,
+                                save_queries: true)
+
+open("legislative/index.json", 'w') do |file|
+  file.write(JSON.pretty_generate(legislatures.map &:as_json ))
+end

--- a/commons-builder.gemspec
+++ b/commons-builder.gemspec
@@ -33,8 +33,10 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'minitest', '~> 5.0'
+  spec.add_development_dependency 'webmock', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'codecov'
+  spec.add_development_dependency 'timecop', '~> 0.9.1'
   spec.add_dependency 'rest-client', '~> 2.0.2'
 
 

--- a/commons-builder.gemspec
+++ b/commons-builder.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
     f.match(%r{^(test|spec|features)/})
   end
   spec.bindir        = 'bin'
-  spec.executables = ['build']
+  spec.executables = ['build', 'generate_legislative_index']
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '~> 1.16'

--- a/lib/commons/builder/legislative_term.rb
+++ b/lib/commons/builder/legislative_term.rb
@@ -1,12 +1,13 @@
 class LegislativeTerm
-  def initialize(legislature:, term_item_id: nil, start_date: nil, end_date: nil)
+  def initialize(legislature:, term_item_id: nil, start_date: nil, end_date: nil, comment: nil)
     @legislature = legislature
     @term_item_id = term_item_id
     @start_date = start_date
     @end_date = end_date
+    @comment = comment
   end
 
-  attr_accessor :legislature, :term_item_id, :start_date, :end_date
+  attr_accessor :legislature, :term_item_id, :start_date, :end_date, :comment
 
   def query(language_map)
     WikidataQueries.new(language_map).query_legislative(

--- a/lib/commons/builder/legislative_term.rb
+++ b/lib/commons/builder/legislative_term.rb
@@ -26,4 +26,25 @@ class LegislativeTerm
       legislature.output_relative.join("#{start_date}-to-#{end_date}")
     end
   end
+
+  def ==(other)
+    other.instance_of?(self.class) &&
+      legislature == other.legislature &&
+      term_item_id == other.term_item_id &&
+      start_date == other.start_date &&
+      end_date == other.end_date &&
+      comment == other.comment
+  end
+
+  def as_json
+    result = {}
+    result[:comment] = @comment if @comment
+    if @term_item_id
+      result[:term_item_id] = @term_item_id if @term_item_id
+    else
+      result[:start_date] = @start_date
+      result[:end_date] = @end_date
+    end
+    result
+  end
 end

--- a/lib/commons/builder/legislature.rb
+++ b/lib/commons/builder/legislature.rb
@@ -14,4 +14,13 @@ class Legislature < Branch
   def terms
     @terms.map { |t| LegislativeTerm.new(legislature: self, **t) }
   end
+
+  def as_json
+    {
+        comment: @comment,
+        house_item_id: @house_item_id,
+        position_item_id: @position_item_id,
+        terms: terms.map { |t| t.as_json },
+    }
+  end
 end

--- a/lib/commons/builder/wikidata.rb
+++ b/lib/commons/builder/wikidata.rb
@@ -1,9 +1,21 @@
+# frozen_string_literal: true
+
+require 'rest-client'
+
 class Wikidata
+  attr_accessor :language_map, :url
 
-  attr_accessor :language_map
-
-  def initialize(language_map)
+  def initialize(language_map, url: 'https://query.wikidata.org/sparql')
     @language_map = language_map
+    @url = url
+  end
+
+  def perform(sparql_query)
+    headers = { 'Content-Type': 'application/sparql-query',
+                'Accept':       'application/sparql-results+json' }
+    result = RestClient.post(url, sparql_query, headers)
+    bindings = JSON.parse(result, symbolize_names: true)[:results][:bindings]
+    bindings.map { |row| Row.new(row) }
   end
 
   def lang_select(prefix='name')

--- a/test/commons/legislative_index_test.rb
+++ b/test/commons/legislative_index_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+require 'timecop'
+require 'webmock/minitest'
+require 'commons/builder/legislature'
+require 'commons/builder/legislative_term'
+
+class Commons::LegislativeIndexTest < Minitest::Test
+  def test_legislative_term_item_as_json
+    term = LegislativeTerm.new({legislature: nil, term_item_id: "Q123", comment: "Test term"})
+    assert_equal term.as_json, {
+      comment:      "Test term",
+      term_item_id: "Q123",
+    }
+  end
+
+  def test_legislative_term_dates_as_json
+    term = LegislativeTerm.new({legislature: nil, start_date: "1970-01-01", end_date: "1970-12-31"})
+    assert_equal term.as_json, {
+      start_date: "1970-01-01",
+      end_date:   "1970-12-31",
+    }
+  end
+end

--- a/test/commons/legislative_index_test.rb
+++ b/test/commons/legislative_index_test.rb
@@ -20,4 +20,19 @@ class Commons::LegislativeIndexTest < Minitest::Test
       end_date:   "1970-12-31",
     }
   end
+
+  def test_legislature_as_json
+    term = {comment: "Term", term_item_id: "Q3"}
+    legislature = Legislature.new(terms: [term], house_item_id: "Q1",
+                                  position_item_id: "Q2", comment: "Test legislature")
+    assert_equal legislature.as_json, {
+      comment:          "Test legislature",
+      house_item_id:    "Q1",
+      position_item_id: "Q2",
+      terms: [{
+        comment:      "Term",
+        term_item_id: "Q3",
+      }]
+    }
+  end
 end

--- a/test/fixtures/legislative-index-terms.srj
+++ b/test/fixtures/legislative-index-terms.srj
@@ -1,0 +1,86 @@
+{
+    "head": {
+        "vars": [
+            "house",
+            "houseLabel",
+            "legislature",
+            "legislatureLabel",
+            "term",
+            "termLabel",
+            "termStart",
+            "termEnd"
+        ]
+    },
+    "results": {
+        "bindings": [
+            {
+                "term": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q21157957"
+                },
+                "termStart": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "type": "literal",
+                    "value": "2015-12-03T00:00:00Z"
+                },
+                "house": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q841180"
+                },
+                "legislature": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q475689"
+                },
+                "houseLabel": {
+                    "xml:lang": "en",
+                    "type": "literal",
+                    "value": "Senate of Canada"
+                },
+                "legislatureLabel": {
+                    "xml:lang": "en",
+                    "type": "literal",
+                    "value": "Parliament of Canada"
+                },
+                "termLabel": {
+                    "xml:lang": "en",
+                    "type": "literal",
+                    "value": "42nd Canadian Parliament"
+                }
+            },
+            {
+                "term": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q19876139"
+                },
+                "termStart": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#dateTime",
+                    "type": "literal",
+                    "value": "2015-06-15T00:00:00Z"
+                },
+                "house": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q1812866"
+                },
+                "legislature": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q6560903"
+                },
+                "houseLabel": {
+                    "xml:lang": "en",
+                    "type": "literal",
+                    "value": "Legislative Assembly of Alberta"
+                },
+                "legislatureLabel": {
+                    "xml:lang": "en",
+                    "type": "literal",
+                    "value": "Legislature of Alberta"
+                },
+                "termLabel": {
+                    "xml:lang": "en",
+                    "type": "literal",
+                    "value": "29th Alberta Legislature"
+                }
+            }
+        ]
+    }
+}

--- a/test/fixtures/legislative-index.srj
+++ b/test/fixtures/legislative-index.srj
@@ -1,0 +1,150 @@
+{
+    "head": {
+        "vars": [
+            "country",
+            "countryLabel",
+            "body",
+            "bodyLabel",
+            "bodyType",
+            "bodyTypeLabel",
+            "legislature",
+            "legislatureLabel",
+            "legislaturePost",
+            "legislaturePostLabel",
+            "numberOfSeats"
+        ]
+    },
+    "results": {
+        "bindings": [
+            {
+                "body": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q1951"
+                },
+                "bodyLabel": {
+                    "xml:lang": "en",
+                    "type": "literal",
+                    "value": "Alberta"
+                },
+                "bodyType": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q10864048"
+                },
+                "bodyTypeLabel": {
+                    "xml:lang": "en",
+                    "type": "literal",
+                    "value": "first-level administrative country subdivision"
+                },
+                "legislature": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q1812866"
+                },
+                "legislatureLabel": {
+                    "xml:lang": "en",
+                    "type": "literal",
+                    "value": "Legislative Assembly of Alberta"
+                },
+                "legislaturePost": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q15964815"
+                },
+                "legislaturePostLabel": {
+                    "xml:lang": "en",
+                    "type": "literal",
+                    "value": "member of Alberta Legislative Assembly"
+                },
+                "numberOfSeats": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#decimal",
+                    "type": "literal",
+                    "value": "87"
+                }
+            },
+            {
+                "body": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q16"
+                },
+                "bodyLabel": {
+                    "xml:lang": "en",
+                    "type": "literal",
+                    "value": "Canada"
+                },
+                "bodyType": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q6256"
+                },
+                "bodyTypeLabel": {
+                    "xml:lang": "en",
+                    "type": "literal",
+                    "value": "country"
+                },
+                "legislature": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q841180"
+                },
+                "legislatureLabel": {
+                    "xml:lang": "en",
+                    "type": "literal",
+                    "value": "Senate of Canada"
+                },
+                "legislaturePost": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q18524027"
+                },
+                "legislaturePostLabel": {
+                    "xml:lang": "en",
+                    "type": "literal",
+                    "value": "Member of the Senate of Canada"
+                },
+                "numberOfSeats": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#decimal",
+                    "type": "literal",
+                    "value": "105"
+                }
+            },
+            {
+                "body": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q36312"
+                },
+                "bodyLabel": {
+                    "xml:lang": "en",
+                    "type": "literal",
+                    "value": "Calgary"
+                },
+                "bodyType": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q515"
+                },
+                "bodyTypeLabel": {
+                    "xml:lang": "en",
+                    "type": "literal",
+                    "value": "city"
+                },
+                "legislature": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q4145705"
+                },
+                "legislatureLabel": {
+                    "xml:lang": "en",
+                    "type": "literal",
+                    "value": "Calgary City Council"
+                },
+                "legislaturePost": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q45414913"
+                },
+                "legislaturePostLabel": {
+                    "xml:lang": "en",
+                    "type": "literal",
+                    "value": "Member of Calgary City Council"
+                },
+                "numberOfSeats": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#decimal",
+                    "type": "literal",
+                    "value": "15"
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
An attempt at addressing #10.

Mostly looks to be doing the right thing on Canada, except:

* ~~doesn't find the existing term for the House of Commons (Q21157957), but I think that's because it's attached to the Parliament, not the house.~~ (I think this is happy now)
* ~~two houses (Q1517320, Q2994129) don't make it in because it doesn't find their position item~~ (one data error fixed in wikidata, the other was the result of a more complex model than expected so was a query fix) 
* Montreal's Borough Mayor (Q47450833) is excluded for not being a councillor or legislator. Is this a wrong interpretation? (still not there)
* The Legislative Assembly of British Columbia (Q1323479) is missing. It looks to be modelled as a part of the Parliament of British Columbia (Q6564780), which could explain it. (haven't reassessed)

~~This also adds a wikidata query function, which could be reused elsewhere to remove duplication.~~ This is now in `Commons::Wikidata`