### PR TITLE
Add a 'seat_counts' attribute to legislatures

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -110,7 +110,15 @@ boundary_data = BoundaryData.new(wikidata_labels)
             },
           ],
           area_id: membership[:org_jurisdiction]&.value,
-        }
+        }.tap do |o|
+          if political_entity_kind == 'legislative'
+            seat_count = membership[:org_seat_count].value
+            if seat_count.to_s.empty?
+              puts "WARNING: no seat count found for the legislature #{wikidata_labels.item_with_label(membership[:org].value)}"
+            end
+            o['seat_counts'] = {membership[:role].value => seat_count}
+          end
+        end
       end.uniq.sort_by { |o| o[:id] }
 
       missing_jurisdictions = entity_organizations.reject { |o| o[:area_id] }

--- a/lib/commons/builder/wikidata_queries.rb
+++ b/lib/commons/builder/wikidata_queries.rb
@@ -28,13 +28,16 @@ class WikidataQueries < Wikidata
              ?district #{lang_select('district_name')}
              ?role #{lang_select('role')}
              ?start ?end ?facebook
-             ?org #{lang_select('org')} ?org_jurisdiction
+             ?org #{lang_select('org')} ?org_jurisdiction ?org_seat_count
       WHERE {
         BIND(wd:#{position_item_id} as ?role) .
         BIND(wd:#{house_item_id} as ?org) .
         #{lang_options('org', '?org')}
         OPTIONAL {
           ?org wdt:P1001 ?org_jurisdiction
+        }
+        OPTIONAL {
+          ?org wdt:P1342 ?org_seat_count
         }
         ?item p:P39 ?statement .
         #{lang_options}


### PR DESCRIPTION
Some organizations are used both as executives and legislatures at the
moment, and we're going to merge the JSON objects for them together at
some point. When we do that, we need to preserve which position the seat
count actually refers to, so I've made seat_counts a hash which maps
position item IDs to the seat count.