### PR TITLE
Include the role_superclass for legislative positions as well

### DIFF
--- a/lib/commons/builder/wikidata_queries.rb
+++ b/lib/commons/builder/wikidata_queries.rb
@@ -27,6 +27,7 @@ class WikidataQueries < Wikidata
              ?party #{lang_select('party_name')}
              ?district #{lang_select('district_name')}
              ?role #{lang_select('role')}
+             ?role_superclass #{lang_select('role_superclass')}
              ?start ?end ?facebook
              ?org #{lang_select('org')} ?org_jurisdiction ?org_seat_count
       WHERE {
@@ -43,6 +44,11 @@ class WikidataQueries < Wikidata
         #{lang_options}
         ?statement ps:P39 ?role .
         #{lang_options('role', '?role')}
+        OPTIONAL {
+          ?role p:P279/ps:P279 ?role_superclass .
+          ?role_superclass p:P279/ps:P279* wd:Q4175034
+          #{lang_options('role_superclass', '?role_superclass')}
+        }
         #{term_condition(term_item_id)}
         OPTIONAL { ?statement pq:P580 ?start }
         OPTIONAL { ?statement pq:P582 ?end }


### PR DESCRIPTION
Consistently having a role_superclass turns out to be useful
downstream, so this commit adds it to the legislative data (it was
already present for executive data).

There is a slightly odd mismatch here, in that the role metadata that
the queries are built from is different between the legislative and
executive directories: for executive, the metadata specifies the
role_superclass, while for legislative it specifies the role.

It would be better if this were consistent, but I think it makes sense
to first get the data included in the build, and then change the
metadata and query generation so they're consistent, checking that the
data produced is the same.