### PR TITLE
Use wdt: instead of p:/ps: for finding role_superclass relationships

### DIFF
--- a/lib/commons/builder/wikidata_queries.rb
+++ b/lib/commons/builder/wikidata_queries.rb
@@ -45,8 +45,8 @@ class WikidataQueries < Wikidata
         ?statement ps:P39 ?role .
         #{lang_options('role', '?role')}
         OPTIONAL {
-          ?role p:P279/ps:P279 ?role_superclass .
-          ?role_superclass p:P279/ps:P279* wd:Q4175034
+          ?role wdt:P279 ?role_superclass .
+          ?role_superclass wdt:P279+ wd:Q4175034
           #{lang_options('role_superclass', '?role_superclass')}
         }
         #{term_condition(term_item_id)}


### PR DESCRIPTION
The p:P279/ps:P279* relation wasn't right - if anything it should have
been (p:P279/ps:P279)* but that always seems to time out. wdt:P279*
works, and we don't know of any cases where using wdt: causes problems
so far, so switch both the constraints on role_superclass to use wdt
instead.

In addition, we use a '+' instead of '*' when checking that
?role_superclass is a subclass (at some level) of 'legislator', so that
we don't end up with ?role_superclass just being 'legislator' (which
isn't useful to know, since we know these are legislative positions
already).