### PR TITLE
Filter statements of deprecated rank [WiP]

### DIFF
--- a/lib/commons/builder/wikidata_queries.rb
+++ b/lib/commons/builder/wikidata_queries.rb
@@ -42,8 +42,11 @@ class WikidataQueries < Wikidata
         }
         ?item p:P39 ?statement .
         #{lang_options}
-        ?statement ps:P39 ?role .
+	?statement ps:P39 ?role .
         #{lang_options('role', '?role')}
+	# Ignore deprecated statements
+	?statement wikibase:rank ?statementRank .
+	FILTER (?statementRank != wikibase:DeprecatedRank)
         OPTIONAL {
           ?role wdt:P279 ?role_superclass .
           ?role_superclass wdt:P279+ wd:Q4175034
@@ -88,6 +91,9 @@ class WikidataQueries < Wikidata
         #{lang_options}
         ?statement ps:P39 ?role .
         #{lang_options('role', '?role')}
+        # Ignore deprecated statements
+        ?statement wikibase:rank ?statementRank .
+        FILTER (?statementRank != wikibase:DeprecatedRank)
         ?role wdt:P279* ?role_superclass .
         #{lang_options('role_superclass', '?role_superclass')}
         ?role wdt:P361 ?org .
@@ -104,6 +110,9 @@ class WikidataQueries < Wikidata
           ?item p:P102 ?party_statement .
           ?party_statement ps:P102 ?party .
           #{lang_options('party_name', '?party')}
+          # Ignore deprecated party statements
+          ?party_statement wikibase:rank ?party_statementRank .
+          FILTER (?party_statementRank != wikibase:DeprecatedRank)
           OPTIONAL { ?party_statement pq:P582 ?end_party }
           BIND(COALESCE(?end_party, "9999-12-31T00:00:00Z"^^xsd:dateTime) AS ?party_end_or_sentinel)
           FILTER(?party_end_or_sentinel >= NOW())
@@ -169,8 +178,9 @@ class WikidataQueries < Wikidata
       SELECT DISTINCT ?house ?houseLabel ?legislature ?legislatureLabel ?term ?termLabel ?termStart ?termEnd WHERE {
         VALUES ?house { #{houses} }
         ?house (p:P361/ps:P361)* ?legislature .
-            ?baseTerm p:P31|p:P279 [ ps:P279|ps:P31 wd:Q15238777 ; pq:P642 ?legislature ] .
+            ?baseTerm p:P31|p:P279 [ ps:P279|ps:P31 wd:Q15238777 ; pq:P642 ?legislature ; wikibase:rank ?houseLegislatureRank] .
             OPTIONAL { ?subTerm wdt:P31 ?baseTerm }
+        FILTER (?houseLegislatureRank != wikibase:DeprecatedRank)
 
         BIND(COALESCE(?subTerm, ?baseTerm) AS ?term)
 


### PR DESCRIPTION
(Mostly) resolves #2.

This misses one, because it's a (p:P361/ps:P361)* path, and I haven't yet
worked out how to make sure that there's at least one path without deprecated
statements (as opposed to FILTERing if there is a path with a deprecated
statement, which would still remove the result if there was a deprecated and a
non-deprecated path). To be fair, it's probably not often that legislatures
lose legislative houses[citation needed].