### PR TITLE
Move to using `languages` (an Array) in place of `language_map`

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -8,9 +8,7 @@ require 'rest-client'
 
 URL = 'https://query.wikidata.org/sparql'
 
-config = Config.new("config.json").values
-LANGUAGE_MAP = config[:language_map]
-COUNTRY_WIKIDATA_ID = config[:country_wikidata_id]
+config = Config.new("config.json")
 
 root_dir = Pathname.new('').dirname
 
@@ -28,7 +26,7 @@ actions = if ARGV.empty?
             ARGV.clone
           end
 
-wikidata_labels = WikidataLabels.new(LANGUAGE_MAP)
+wikidata_labels = WikidataLabels.new(config.languages)
 
 boundaries_dir = Dir.exist?('boundaries/build') ? 'boundaries/build' : 'boundaries'
 boundary_data = BoundaryData.new(wikidata_labels, boundaries_dir: boundaries_dir)
@@ -48,7 +46,7 @@ boundary_position_ids = boundary_data.popolo_areas.map { |a| a[:associated_wikid
       raw_results_pathname = output_dir.join('query-results.json')
 
       if actions.include? 'update'
-        sparql_query = term.query(LANGUAGE_MAP)
+        sparql_query = term.query(config.languages)
         output_dir.join('query-used.rq').write(sparql_query)
 
         query_params = {
@@ -64,7 +62,7 @@ boundary_position_ids = boundary_data.popolo_areas.map { |a| a[:associated_wikid
       data = JSON.parse(raw_results_pathname.read, symbolize_names: true)
 
       membership_rows = data[:results][:bindings].map do |row|
-        WikidataRow.new(row, LANGUAGE_MAP)
+        WikidataRow.new(row, config.languages)
       end
 
       persons = membership_rows.map do |membership|
@@ -163,7 +161,7 @@ boundary_position_ids = boundary_data.popolo_areas.map { |a| a[:associated_wikid
       # Check that none of these have a null person_id - we should only
       # allow that for the whole-country area.
       areas_with_bad_parents = areas.select do |area|
-        area[:parent_id].nil? && !area[:id] == COUNTRY_WIKIDATA_ID
+        area[:parent_id].nil? && !area[:id] == config.country_wikidata_id
       end
       unless areas_with_bad_parents.empty?
         areas_with_bad_parents.each do |area|

--- a/bin/generate_executive_index
+++ b/bin/generate_executive_index
@@ -6,11 +6,10 @@ require 'json'
 require 'commons/builder'
 
 
-config = Config.new("config.json").values
-LANGUAGE_MAP = config[:language_map]
-COUNTRY_WIKIDATA_ID = config[:country_wikidata_id]
+config = Config.new("config.json")
 
-executives = Executive.list(COUNTRY_WIKIDATA_ID, LANGUAGE_MAP,
+executives = Executive.list(config.country_wikidata_id,
+                            config.languages,
                             save_queries: true)
 
 open('executive/index.json', 'w') do |file|

--- a/bin/generate_legislative_index
+++ b/bin/generate_legislative_index
@@ -6,11 +6,10 @@ require 'json'
 require 'commons/builder'
 
 
-config = Config.new("config.json").values
-LANGUAGE_MAP = config[:language_map]
-COUNTRY_WIKIDATA_ID = config[:country_wikidata_id]
+config = Config.new("config.json")
 
-legislatures = Legislature.list(COUNTRY_WIKIDATA_ID, LANGUAGE_MAP,
+legislatures = Legislature.list(config.country_wikidata_id,
+                                config.languages,
                                 save_queries: true)
 
 open("legislative/index.json", 'w') do |file|

--- a/lib/commons/builder/config.rb
+++ b/lib/commons/builder/config.rb
@@ -5,7 +5,6 @@ require 'pathname'
 
 
 class Config
-
   attr_reader :values
 
   def initialize(file)
@@ -15,4 +14,18 @@ class Config
     )
   end
 
+  def languages
+    @languages ||= begin
+      if values[:languages]
+        values[:languages]
+      else
+        puts "WARNING: config.json should now use a list of language codes"
+        values[:language_map].values
+      end
+    end
+  end
+
+  def country_wikidata_id
+    @country_wikidata_id ||= values[:country_wikidata_id]
+  end
 end

--- a/lib/commons/builder/current_executive.rb
+++ b/lib/commons/builder/current_executive.rb
@@ -5,8 +5,8 @@ class CurrentExecutive
 
   attr_accessor :executive
 
-  def query(language_map)
-    WikidataQueries.new(language_map).query_executive(
+  def query(languages)
+    WikidataQueries.new(languages).query_executive(
       executive_item_id: executive.executive_item_id,
       positions: executive.positions
     )

--- a/lib/commons/builder/executive.rb
+++ b/lib/commons/builder/executive.rb
@@ -21,9 +21,9 @@ class Executive < Branch
     @positions.map { |t| Position.new(branch: self, **t) }
   end
 
-  def self.list(country_id, language_map, save_queries: false)
-    wikidata_queries = WikidataQueries.new(language_map)
-    wikidata_labels = WikidataLabels.new(language_map)
+  def self.list(country_id, languages, save_queries: false)
+    wikidata_queries = WikidataQueries.new(languages)
+    wikidata_labels = WikidataLabels.new(languages)
     sparql_query = wikidata_queries.query_executive_index(country_id)
 
     executives = wikidata_queries.perform(sparql_query)

--- a/lib/commons/builder/legislative_term.rb
+++ b/lib/commons/builder/legislative_term.rb
@@ -9,8 +9,8 @@ class LegislativeTerm
 
   attr_accessor :legislature, :term_item_id, :start_date, :end_date, :comment
 
-  def query(language_map)
-    WikidataQueries.new(language_map).query_legislative(
+  def query(languages)
+    WikidataQueries.new(languages).query_legislative(
       position_item_id: legislature.position_item_id,
       house_item_id: legislature.house_item_id,
       term_item_id: term_item_id,

--- a/lib/commons/builder/legislature.rb
+++ b/lib/commons/builder/legislature.rb
@@ -15,8 +15,8 @@ class Legislature < Branch
     @terms.map { |t| LegislativeTerm.new(legislature: self, **t) }
   end
 
-  def self.list(country_id, language_map, save_queries: false)
-    wikidata_queries = WikidataQueries.new(language_map)
+  def self.list(country_id, languages, save_queries: false)
+    wikidata_queries = WikidataQueries.new(languages)
     sparql_query = wikidata_queries.query_legislative_index(country_id)
 
     open('legislative/index-query-used.rq', 'w').write(sparql_query) if save_queries

--- a/lib/commons/builder/wikidata.rb
+++ b/lib/commons/builder/wikidata.rb
@@ -3,10 +3,10 @@
 require 'rest-client'
 
 class Wikidata
-  attr_accessor :language_map, :url
+  attr_accessor :languages, :url
 
-  def initialize(language_map, url: 'https://query.wikidata.org/sparql')
-    @language_map = language_map
+  def initialize(languages, url: 'https://query.wikidata.org/sparql')
+    @languages = languages
     @url = url
   end
 
@@ -15,11 +15,11 @@ class Wikidata
                 'Accept':       'application/sparql-results+json' }
     result = RestClient.post(url, sparql_query, headers)
     bindings = JSON.parse(result, symbolize_names: true)[:results][:bindings]
-    bindings.map { |row| WikidataRow.new(row, language_map) }
+    bindings.map { |row| WikidataRow.new(row, languages) }
   end
 
   def lang_select(prefix='name')
-    language_map.values.map { |l| variable(prefix, l) }.join(' ')
+    languages.map { |l| variable(prefix, l) }.join(' ')
   end
 
   def variable(prefix, lang_code, query=true)
@@ -31,7 +31,7 @@ class Wikidata
   end
 
   def lang_options(prefix='name', item='?item')
-    language_map.values.map do |l|
+    languages.map do |l|
       "OPTIONAL {
           #{item} rdfs:label #{variable(prefix, l)}
           FILTER(LANG(#{variable(prefix, l)}) = \"#{l}\")

--- a/lib/commons/builder/wikidata_labels.rb
+++ b/lib/commons/builder/wikidata_labels.rb
@@ -9,11 +9,10 @@ class WikidataLabels < Wikidata
   def label_for(wikidata_item_id)
     all_labels = labels_for(wikidata_item_id)
     return nil if all_labels.nil?
-    preferred_language_order = LANGUAGE_MAP.keys
-    languages = all_labels.keys.sort_by do |l|
-      preferred_language_order.index(l)
+    label_languages = all_labels.keys.sort_by do |l|
+      languages.index(l)
     end
-    all_labels.values_at(*languages).first
+    all_labels.values_at(*label_languages).first
   end
 
   def labels_for(wikidata_item_id)

--- a/lib/commons/builder/wikidata_queries.rb
+++ b/lib/commons/builder/wikidata_queries.rb
@@ -23,8 +23,8 @@ class WikidataQueries < Wikidata
   # to end-users, as that needs potentially multiple language-tagged labels.
   # For that, use `lang_select` and `lang_options`.
   def label_service
-    languages = (["en"] + language_map.values).uniq
-    "SERVICE wikibase:label { bd:serviceParam wikibase:language \"#{languages.join(',')}\". }"
+    languages_with_en = (["en"] + languages).uniq
+    "SERVICE wikibase:label { bd:serviceParam wikibase:language \"#{languages_with_en.join(',')}\". }"
   end
 
   def query_legislative(position_item_id:, house_item_id:, term_item_id: nil, start_date: nil, end_date: nil, **_)

--- a/lib/commons/builder/wikidata_results.rb
+++ b/lib/commons/builder/wikidata_results.rb
@@ -42,11 +42,11 @@ end
 
 class WikidataRow < Wikidata
 
-  attr_accessor :language_map
+  attr_accessor :languages
 
-  def initialize(row_h, language_map)
+  def initialize(row_h, languages)
     @row_h = row_h
-    @language_map = language_map
+    @languages = languages
   end
 
   def [](key)
@@ -55,10 +55,10 @@ class WikidataRow < Wikidata
   end
 
   def name_object(var_prefix)
-    language_map.map do |key_lang, wikidata_lang|
+    languages.map do |wikidata_lang|
       column = variable(var_prefix, wikidata_lang, false).to_sym
       [
-        key_lang,
+        "lang:#{wikidata_lang}",
         self[column]&.value,
       ]
     end.to_h.compact

--- a/test/commons/builder/config_test.rb
+++ b/test/commons/builder/config_test.rb
@@ -3,8 +3,22 @@ require 'test_helper'
 class Commons::ConfigTest < Minitest::Test
 
   def test_can_access_json_values
-    config = Config.new('test/fixtures/config/config.json').values
-    assert_equal('Q23666', config[:country_wikidata_id])
+    config = Config.new('test/fixtures/config/config.json')
+    assert_equal('Q23666', config.values[:country_wikidata_id])
   end
 
+  def test_can_access_languages
+    config = Config.new('test/fixtures/config/config.json')
+    assert_equal(['en', 'es'], config.languages)
+  end
+
+  def test_can_access_country_wikidata_id
+    config = Config.new('test/fixtures/config/config.json')
+    assert_equal('Q23666', config.country_wikidata_id)
+  end
+
+  def test_can_infer_languages_from_language_map
+    config = Config.new('test/fixtures/config/config-with-language-map.json')
+    assert_equal(['en', 'es'], config.languages)
+  end
 end

--- a/test/commons/builder/executive_test.rb
+++ b/test/commons/builder/executive_test.rb
@@ -20,8 +20,8 @@ class ExecutiveTest < Minitest::Test
     stub_request(:post, "https://query.wikidata.org/sparql").
         to_return(body: open('test/fixtures/executive-index.srj', 'r'))
 
-    language_map = { "lang:en_US": "en" }
-    executives = Executive.list("Q16", language_map)
+    languages = ["en"]
+    executives = Executive.list("Q16", languages)
     assert_equal 3, executives.length
     assert_equal "Queen's Privy Council for Canada", executives[0].comment
     assert_equal 'Q1631137', executives[0].executive_item_id
@@ -35,8 +35,8 @@ class ExecutiveTest < Minitest::Test
         to_return(body: open('test/fixtures/executive-index-missing-executive.srj', 'r')).then.
         to_return(body: '[]')
 
-    language_map = { "lang:en_US": "en" }
-    executives = Executive.list("Q16", language_map)
+    languages = ["en"]
+    executives = Executive.list("Q16", languages)
     assert_equal [], executives
   end
 
@@ -45,8 +45,8 @@ class ExecutiveTest < Minitest::Test
         to_return(body: open('test/fixtures/executive-index-missing-position.srj', 'r')).then.
         to_return(body: '[]')
 
-    language_map = { "lang:en_US": "en" }
-    executives = Executive.list("Q16", language_map)
+    languages = ["en"]
+    executives = Executive.list("Q16", languages)
     assert_equal [], executives
   end
 end

--- a/test/commons/builder/wikidata_results_test.rb
+++ b/test/commons/builder/wikidata_results_test.rb
@@ -7,11 +7,9 @@ class Commons::WikidataResultsTest < Minitest::Test
                                  :type => "literal",
                                  :value => "Kuomintang" }
             }
-    language_map = {
-      "lang:en_US": "en"
-    }
-    row = WikidataRow.new(data, language_map)
-    expected = { :"lang:en_US" => "Kuomintang" }
+    languages = ["en"]
+    row = WikidataRow.new(data, languages)
+    expected = { "lang:en" => "Kuomintang" }
     assert_equal(expected, row.name_object('party_name'))
   end
 
@@ -23,12 +21,9 @@ class Commons::WikidataResultsTest < Minitest::Test
                                     :type => "literal",
                                     :value => "中國國民黨" }
             }
-    language_map = {
-      "lang:zh_TW": "zh-tw",
-      "lang:en_US": "en"
-    }
-    row = WikidataRow.new(data, language_map)
-    expected = { :"lang:en_US" => "Kuomintang", :"lang:zh_TW" => "中國國民黨" }
+    languages = ["zh-tw", "en"]
+    row = WikidataRow.new(data, languages)
+    expected = { "lang:en" => "Kuomintang", "lang:zh-tw" => "中國國民黨" }
     assert_equal(expected, row.name_object('party_name'))
   end
 

--- a/test/commons/builder/wikidata_test.rb
+++ b/test/commons/builder/wikidata_test.rb
@@ -2,29 +2,29 @@ require 'test_helper'
 
 class Commons::WikidataTest < Minitest::Test
 
-  def test_accepts_language_map
-    language_map = { "lang:en_US": "en" }
-    wikidata = Wikidata.new(language_map)
-    assert_equal(language_map, wikidata.language_map)
+  def test_accepts_languages
+    languages = ["en"]
+    wikidata = Wikidata.new(languages)
+    assert_equal(languages, wikidata.languages)
   end
 
   def test_lang_select_returns_space_delimited_names
-    language_map = { "lang:en_US": "en" }
-    wikidata = Wikidata.new(language_map)
+    languages = ["en"]
+    wikidata = Wikidata.new(languages)
     expected = "?name_en"
     assert_equal(expected, wikidata.lang_select)
   end
 
   def test_lang_select_converts_hypens
-    language_map = { "lang:zh_TW": "zh-tw" }
-    wikidata = Wikidata.new(language_map)
+    languages = ["zh-tw"]
+    wikidata = Wikidata.new(languages)
     expected = "?name_zh_tw"
     assert_equal(expected, wikidata.lang_select)
   end
 
   def test_lang_options_returns_optional_filter
-    language_map = { "lang:en_US": "en" }
-    wikidata = Wikidata.new(language_map)
+    languages = ["en"]
+    wikidata = Wikidata.new(languages)
     expected = <<-EOF
 OPTIONAL {
           ?item rdfs:label ?name_en
@@ -35,8 +35,8 @@ EOF
   end
 
   def test_lang_options_converts_hypens
-    language_map = { "lang:zh_TW": "zh-tw" }
-    wikidata = Wikidata.new(language_map)
+    languages = ["zh-tw"]
+    wikidata = Wikidata.new(languages)
     expected = <<-EOF
 OPTIONAL {
           ?item rdfs:label ?name_zh_tw

--- a/test/commons/legislative_index_test.rb
+++ b/test/commons/legislative_index_test.rb
@@ -42,8 +42,8 @@ class Commons::LegislativeIndexTest < Minitest::Test
         to_return(body: open('test/fixtures/legislative-index-terms.srj', 'r'))
 
     Timecop.freeze(Date.new(2010, 01, 01)) do
-      language_map = { "lang:en_US": "en" }
-      legislatures = Legislature.list("Q16", language_map)
+      languages = ["en"]
+      legislatures = Legislature.list("Q16", languages)
       assert_equal "Senate of Canada", legislatures[0].comment
       assert_equal LegislativeTerm.new(legislature: legislatures[0],
                                        term_item_id: 'Q21157957',

--- a/test/fixtures/config/config-with-language-map.json
+++ b/test/fixtures/config/config-with-language-map.json
@@ -1,0 +1,7 @@
+{
+    "language_map": {
+      "en_US": "en",
+      "es_LA": "es"
+    },
+    "country_wikidata_id": "Q23666"
+}

--- a/test/fixtures/config/config.json
+++ b/test/fixtures/config/config.json
@@ -1,6 +1,7 @@
 {
-    "language_map": {
-      "en_US": "en"
-    },
+    "languages": [
+      "en",
+      "es"
+    ],
     "country_wikidata_id": "Q23666"
 }


### PR DESCRIPTION
This is intended to remove Facebook-specific language codes from our commons
repositories. The mapping to Facebook codes can and should happen further
downstream in the data pipeline.

WiP. This will be split up and possibly tidied before being merged.

General idea:

* Multilingual labels exposed with `wmf:[wikidatalang]` keys, instead of the
  previous `lang:[fblang]` keys. The `wmf:` part is supposed to hint at these
  being Wikimedia Foundation language codes, but I'm open to alternative
  suggestions for what this should look like.
* Config objects now expose languages and country_wikidata_id through
  accessors, not by exposing their inner values.
* Config.languages now encapsulates falling back to language_map with a
  warning.
* All instances of language_map.values replaced with languages
* Tests updated