### PR TITLE
Change order of statements to ensure queries saved before running.

### DIFF
--- a/lib/commons/builder/executive.rb
+++ b/lib/commons/builder/executive.rb
@@ -26,8 +26,8 @@ class Executive < Branch
     wikidata_labels = WikidataLabels.new(languages)
     sparql_query = wikidata_queries.query_executive_index(country_id)
 
-    executives = wikidata_queries.perform(sparql_query)
     open('executive/index-query-used.rq', 'w').write(sparql_query) if save_queries
+    executives = wikidata_queries.perform(sparql_query)
 
     executives.select! do |row|
       unless row[:position]&.value

--- a/lib/commons/builder/legislature.rb
+++ b/lib/commons/builder/legislature.rb
@@ -26,8 +26,8 @@ class Legislature < Branch
     sparql_query = wikidata_queries.query_legislative_index_terms(
       *legislatures.map { |legislature| legislature[:legislature].value }
     )
-    term_rows = wikidata_queries.perform(sparql_query)
     open('legislative/index-terms-query-used.rq', 'w').write(sparql_query) if save_queries
+    term_rows = wikidata_queries.perform(sparql_query)
 
     terms_by_legislature = Hash.new { |h, k| h[k] = [] }
 


### PR DESCRIPTION
This ensures in `Executive.list` and `Legislature.list` that queries are always written to disk before attempting to executive then against the Wikdiata SPARQL endpoint.

Closes #46, as it supports easier debugging of queries that don't return. See that issue for a description of the problem.

Not including tests as this isn't a functional change.