### PR TITLE
s/FILTER NOT EXISTS/MINUS/ in executive index query

### DIFF
--- a/lib/commons/builder/wikidata_queries.rb
+++ b/lib/commons/builder/wikidata_queries.rb
@@ -140,7 +140,7 @@ class WikidataQueries < Wikidata
              wdt:P1082 ?population .
           FILTER (?population > 250000)
           # Make sure the city is not also a FLACS
-          FILTER NOT EXISTS { ?adminArea wdt:P31/wdt:P279* wd:Q10864048 }
+          MINUS { ?adminArea wdt:P31/wdt:P279* wd:Q10864048 }
           VALUES (?primarySort ?adminAreaType) { (3 wd:Q515) }
         }
       } ORDER BY ?primarySort


### PR DESCRIPTION
This change makes the executive index query return far more quickly, resolving the problem with timeouts documented in #45. Hence, this closes #45.

In almost all circumstances — including this one — `FILTER NOT EXISTS` and `MINUS` are functionally equivalent, but `MINUS` is far more performant here. In short, `FILTER NOT EXISTS` will be constructing the bracketed resultset anew for each `?adminArea`, whereas `MINUS` will be constructing it once and minusing those results from previous results.

No tests, as this is non-functional change.