### PR TITLE
Allow additional admin areas to be specified in config.yaml

### DIFF
--- a/lib/commons/builder/config.rb
+++ b/lib/commons/builder/config.rb
@@ -30,9 +30,14 @@ class Config
     @country_wikidata_id ||= values[:country_wikidata_id]
   end
 
+  def additional_admin_area_ids
+    @additional_admin_area_ids ||= values[:additional_admin_area_ids] || []
+  end
+
   def to_liquid
     # These variables are available in liquid templates
     {
+      'additional_admin_area_ids' => additional_admin_area_ids,
       'country_wikidata_id' => country_wikidata_id,
       'languages' => languages,
     }

--- a/lib/commons/builder/queries/select_admin_areas_for_country.rq.liquid
+++ b/lib/commons/builder/queries/select_admin_areas_for_country.rq.liquid
@@ -15,5 +15,11 @@ SELECT DISTINCT ?primarySort ?adminArea ?adminAreaType {
     # Make sure the city is not also a FLACS
     MINUS { ?adminArea wdt:P31/wdt:P279* wd:Q10864048 }
     VALUES (?primarySort ?adminAreaType) { (3 wd:Q515) }
-  }
+  }{% if config.additional_admin_area_ids %} UNION {
+    VALUES (?adminArea ?primarySort ?adminAreaType) {
+{%- for admin_area_id in config.additional_admin_area_ids %}
+      (wd:{{ admin_area_id }} 4 wd:Q24238356)
+{%- endfor %}
+    }
+  }{% endif %}
 } ORDER BY ?primarySort

--- a/test/commons/builder/config_test.rb
+++ b/test/commons/builder/config_test.rb
@@ -28,5 +28,15 @@ module Commons
       config = Config.new_from_file('test/fixtures/config/config-with-language-map.json')
       assert_equal(%w[en es], config.languages)
     end
+
+    def test_no_additional_admin_areas
+      config = Config.new_from_file('test/fixtures/config/config.json')
+      assert_equal([], config.additional_admin_area_ids)
+    end
+
+    def test_additional_admin_areas
+      config = Config.new_from_file('test/fixtures/config/config-additional-admin-areas.json')
+      assert_equal(%w[Q1 Q2], config.additional_admin_area_ids)
+    end
   end
 end

--- a/test/commons/builder/wikidata_queries_test.rb
+++ b/test/commons/builder/wikidata_queries_test.rb
@@ -78,4 +78,12 @@ class WikidataQueriesTest < Minitest::Test
     template = '{% for l in config.languages %}{{ l }}{% unless forloop.last %}, {% endunless %}{% endfor %}'
     assert_equal 'en, es', wikidata_queries.templated_query_from_string('q5', template)
   end
+
+  def test_additional_areas_in_admin_areas
+    wikidata_queries = WikidataQueries.new Config.new(languages: ['en'],
+                                                      country_wikidata_id: 'Q16',
+                                                      additional_admin_area_ids: %w[Q1234 Q1235])
+    assert_match(/\(wd:Q1234 4 wd:Q24238356\)\s+\(wd:Q1235 4 wd:Q24238356\)/,
+                 wikidata_queries.templated_query('select_admin_areas_for_country'))
+  end
 end

--- a/test/fixtures/config/config-additional-admin-areas.json
+++ b/test/fixtures/config/config-additional-admin-areas.json
@@ -1,0 +1,11 @@
+{
+  "languages": [
+    "en",
+    "es"
+  ],
+  "country_wikidata_id": "Q23666",
+  "additional_admin_area_ids": [
+    "Q1",
+    "Q2"
+  ]
+}


### PR DESCRIPTION
This adds:

* Support for an optional `additional_admin_area_ids` key in `config.json`, taking an array.
* An extension to the `select_admin_areas_for_country` query to include an additional UNION clause to return the given areas
* Tests for the changes to `Config`, and to ensure that the template includes the right `VALUES` entries