### PR TITLE
Split each query out into its own template

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -46,7 +46,7 @@ Style/CaseEquality:
 # Offense count: 2
 Style/DoubleNegation:
   Exclude:
-    - 'lib/commons/builder/wikidata_queries.rb'
+    - 'lib/commons/builder/legislative_term.rb'
 
 # Offense count: 1
 # Configuration parameters: MinBodyLength.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     commons-builder (0.1.0)
+      liquid
       rest-client (~> 2.0.2)
 
 GEM
@@ -17,12 +18,13 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     docile (1.1.5)
-    domain_name (0.5.20170404)
+    domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     hashdiff (0.3.7)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     json (2.1.0)
+    liquid (4.0.0)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
@@ -56,7 +58,7 @@ GEM
     timecop (0.9.1)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.4)
+    unf_ext (0.0.7.5)
     unicode-display_width (1.3.2)
     url (0.3.2)
     webmock (2.3.2)
@@ -76,6 +78,9 @@ DEPENDENCIES
   rubocop (~> 0.53.0)
   timecop (~> 0.9.1)
   webmock (~> 2.0)
+
+RUBY VERSION
+   ruby 2.4.3p205
 
 BUNDLED WITH
    1.16.1

--- a/commons-builder.gemspec
+++ b/commons-builder.gemspec
@@ -40,5 +40,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 0.53.0'
   spec.add_development_dependency 'timecop', '~> 0.9.1'
   spec.add_development_dependency 'webmock', '~> 2.0'
+  spec.add_dependency 'liquid'
   spec.add_dependency 'rest-client', '~> 2.0.2'
 end

--- a/lib/commons/builder/current_executive.rb
+++ b/lib/commons/builder/current_executive.rb
@@ -8,10 +8,9 @@ class CurrentExecutive
   attr_accessor :executive
 
   def query(languages)
-    WikidataQueries.new(languages).query_executive(
-      executive_item_id: executive.executive_item_id,
-      positions: executive.positions
-    )
+    WikidataQueries.new(languages).templated_query('executive',
+                                                   executive_item_id: executive.executive_item_id,
+                                                   positions: executive.positions.map(&:position_item_id))
   end
 
   def output_relative

--- a/lib/commons/builder/executive.rb
+++ b/lib/commons/builder/executive.rb
@@ -26,7 +26,7 @@ class Executive < Branch
   def self.list(country_id, languages, save_queries: false)
     wikidata_queries = WikidataQueries.new(languages)
     wikidata_labels = WikidataLabels.new(languages)
-    sparql_query = wikidata_queries.query_executive_index(country_id)
+    sparql_query = wikidata_queries.templated_query('executive_index', country: country_id)
 
     open('executive/index-query-used.rq', 'w').write(sparql_query) if save_queries
     executives = wikidata_queries.perform(sparql_query)

--- a/lib/commons/builder/legislative_term.rb
+++ b/lib/commons/builder/legislative_term.rb
@@ -2,6 +2,7 @@
 
 class LegislativeTerm
   def initialize(legislature:, term_item_id: nil, start_date: nil, end_date: nil, comment: nil)
+    raise 'You must specify a term item or a start and end date' if !term_item_id && !(start_date and end_date)
     @legislature = legislature
     @term_item_id = term_item_id
     @start_date = start_date

--- a/lib/commons/builder/legislative_term.rb
+++ b/lib/commons/builder/legislative_term.rb
@@ -13,13 +13,12 @@ class LegislativeTerm
   attr_accessor :legislature, :term_item_id, :start_date, :end_date, :comment
 
   def query(languages)
-    WikidataQueries.new(languages).query_legislative(
-      position_item_id: legislature.position_item_id,
-      house_item_id: legislature.house_item_id,
-      term_item_id: term_item_id,
-      start_date: start_date,
-      end_date: end_date
-    )
+    WikidataQueries.new(languages).templated_query('legislative',
+                                                   position_item_id: legislature.position_item_id,
+                                                   house_item_id: legislature.house_item_id,
+                                                   term_item_id: term_item_id,
+                                                   start_date: start_date,
+                                                   end_date: end_date)
   end
 
   def output_relative

--- a/lib/commons/builder/legislature.rb
+++ b/lib/commons/builder/legislature.rb
@@ -19,14 +19,15 @@ class Legislature < Branch
 
   def self.list(country_id, languages, save_queries: false)
     wikidata_queries = WikidataQueries.new(languages)
-    sparql_query = wikidata_queries.query_legislative_index(country_id)
+    sparql_query = wikidata_queries.templated_query('legislative_index', country: country_id)
 
     open('legislative/index-query-used.rq', 'w').write(sparql_query) if save_queries
     legislatures = wikidata_queries.perform(sparql_query)
 
     # Now collect term information
-    sparql_query = wikidata_queries.query_legislative_index_terms(
-      *legislatures.map { |legislature| legislature[:legislature].value }
+    sparql_query = wikidata_queries.templated_query(
+      'legislative_index_terms',
+      houses: legislatures.map { |legislature| legislature[:legislature].value }
     )
     open('legislative/index-terms-query-used.rq', 'w').write(sparql_query) if save_queries
     term_rows = wikidata_queries.perform(sparql_query)

--- a/lib/commons/builder/queries/date_condition.rq.liquid
+++ b/lib/commons/builder/queries/date_condition.rq.liquid
@@ -1,6 +1,6 @@
-{% if start_date -%}
+{% if start_date %}{% unless term_item_id -%}
 BIND(COALESCE(?start, "1000-01-01T00:00:00Z"^^xsd:dateTime) AS ?start_or_sentinel)
 BIND(COALESCE(?end, "9999-12-31T00:00:00Z"^^xsd:dateTime) AS ?end_or_sentinel)
 FILTER (?end_or_sentinel >= "{{ start_date }}"^^xsd:dateTime)
 FILTER (?start_or_sentinel <= "{{ end_date }}"^^xsd:dateTime)
-{% endif -%}
+{% endunless %}{% endif -%}

--- a/lib/commons/builder/queries/date_condition.rq.liquid
+++ b/lib/commons/builder/queries/date_condition.rq.liquid
@@ -1,0 +1,6 @@
+{% if start_date -%}
+BIND(COALESCE(?start, "1000-01-01T00:00:00Z"^^xsd:dateTime) AS ?start_or_sentinel)
+BIND(COALESCE(?end, "9999-12-31T00:00:00Z"^^xsd:dateTime) AS ?end_or_sentinel)
+FILTER (?end_or_sentinel >= "{{ start_date }}"^^xsd:dateTime)
+FILTER (?start_or_sentinel <= "{{ end_date }}"^^xsd:dateTime)
+{% endif -%}

--- a/lib/commons/builder/queries/executive.rq.liquid
+++ b/lib/commons/builder/queries/executive.rq.liquid
@@ -1,0 +1,41 @@
+SELECT ?statement
+       ?item {% lang_select 'name' %}
+       ?party {% lang_select 'party_name' %}
+       ?district {% lang_select 'district_name' %}
+       ?role {% lang_select 'role' %}
+       ?start ?end ?facebook
+       ?role_superclass {% lang_select 'role_superclass' %}
+       ?org {% lang_select 'org' %} ?org_jurisdiction
+WHERE {
+  VALUES ?role_superclass { {% for position_item_id in position_item_ids %}wd:{{ position_item_id }} {% endfor %}}
+  BIND(wd:{{ executive_item_id }} AS ?org)
+  {% lang_options 'org' '?org' %}
+  OPTIONAL {
+    ?org wdt:P1001 ?org_jurisdiction
+  }
+  ?item p:P39 ?statement .
+  {% lang_options 'name' '?item' %}
+  ?statement ps:P39 ?role .
+  {% lang_options 'role' '?role' %}
+  ?role wdt:P279* ?role_superclass .
+  {% lang_options 'role_superclass' '?role_superclass' %}
+  ?role wdt:P361 ?org .
+  OPTIONAL {
+    ?role p:P1001/ps:P1001 ?district .
+    {% lang_options 'district_name' '?district' %}
+  }
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  BIND(COALESCE(?end, "9999-12-31T00:00:00Z"^^xsd:dateTime) AS ?end_or_sentinel)
+  FILTER(?end_or_sentinel >= NOW())
+  # Find any current party membership:
+  OPTIONAL {
+    ?item p:P102 ?party_statement .
+    ?party_statement ps:P102 ?party .
+    {% lang_options 'party_name' '?party' %}
+    OPTIONAL { ?party_statement pq:P582 ?end_party }
+    BIND(COALESCE(?end_party, "9999-12-31T00:00:00Z"^^xsd:dateTime) AS ?party_end_or_sentinel)
+    FILTER(?party_end_or_sentinel >= NOW())
+  }
+  OPTIONAL { ?item wdt:P2013 ?facebook }
+} ORDER BY ?item ?role ?district ?start ?end

--- a/lib/commons/builder/queries/executive_index.rq.liquid
+++ b/lib/commons/builder/queries/executive_index.rq.liquid
@@ -1,0 +1,29 @@
+SELECT DISTINCT ?executive ?executiveLabel ?adminArea ?adminAreaLabel ?adminAreaType ?adminAreaTypeLabel ?position ?positionLabel {
+  {
+    {% include 'select_admin_areas_for_country' %}
+  }
+
+  OPTIONAL {
+    {
+      ?position p:P1001 [ wikibase:rank ?appliesToJurisdictionRank ; ps:P1001 ?adminArea ] ;
+        wdt:P31/wdt:P279* wd:Q4164871 .
+      FILTER (?appliesToJurisdictionRank != wikibase:DeprecatedRank)
+      FILTER EXISTS {
+        VALUES ?positionSuperclass { wd:Q2285706 wd:Q30461 }
+        ?position wdt:P279* ?positionSuperclass .
+      }
+    } UNION {
+      ?adminArea wdt:P1313 ?position
+    }
+
+    OPTIONAL {
+      ?position wdt:P361 ?executive .
+      # Exclude executives that are privy councils
+      FILTER NOT EXISTS { ?executive wdt:P31/wdt:P279* wd:Q6528244 }
+      # Exclude executives which aren't direct parents of the position
+      FILTER NOT EXISTS { ?position wdt:P361 ?other . ?other wdt:P361+ ?executive }
+    }
+  }
+
+  {% include 'label_service' %}
+} ORDER BY ?primarySort ?country ?adminAreaType ?executive ?position

--- a/lib/commons/builder/queries/label_service.rq.liquid
+++ b/lib/commons/builder/queries/label_service.rq.liquid
@@ -1,0 +1,11 @@
+{% comment %}
+  Use this to generate a `SERVICE wikibase:label` SPARQL pattern, for use in
+  situations where you want a single label to help the humans that maintain
+  a democratic commons repository. Do not use it for labels to be presented
+  to end-users, as that needs potentially multiple language-tagged labels.
+  For that, use `lang_select` and `lang_options`.
+{% endcomment -%}
+SERVICE wikibase:label { bd:serviceParam wikibase:language "en
+  {%- for language in languages %}
+    {%- if language != "en" %},{{ language }}{% endif %}
+  {%- endfor %}". }

--- a/lib/commons/builder/queries/legislative.rq.liquid
+++ b/lib/commons/builder/queries/legislative.rq.liquid
@@ -1,0 +1,41 @@
+SELECT ?statement
+       ?item {% lang_select 'name' %}
+       ?party {% lang_select 'party_name' %}
+       ?district {% lang_select 'district_name' %}
+       ?role {% lang_select 'role' %}
+       ?role_superclass {% lang_select 'role_superclass' %}
+       ?start ?end ?facebook
+       ?org {% lang_select 'org' %} ?org_jurisdiction ?org_seat_count
+WHERE {
+  BIND(wd:{{ position_item_id }} as ?role) .
+  BIND(wd:{{ house_item_id }} as ?org) .
+  {% lang_options 'org' '?org' %}
+  OPTIONAL {
+    ?org wdt:P1001 ?org_jurisdiction
+  }
+  OPTIONAL {
+    ?org wdt:P1342 ?org_seat_count
+  }
+  ?item p:P39 ?statement .
+  {% lang_options 'name' '?item' %}
+  ?statement ps:P39 ?role .
+  {% lang_options 'role' '?role' %}
+  OPTIONAL {
+    ?role wdt:P279 ?role_superclass .
+    ?role_superclass wdt:P279+ wd:Q4175034
+    {% lang_options 'role_superclass' '?role_superclass' %}
+  }
+  {% include 'term_condition' %}
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  OPTIONAL {
+    ?statement pq:P768 ?district.
+    {% lang_options 'district_name' '?district' %}
+  }
+  OPTIONAL {
+    ?statement pq:P4100 ?party.
+    {% lang_options 'party_name' '?party' %}
+  }
+  OPTIONAL { ?item wdt:P2013 ?facebook }
+  {% include 'date_condition' %}
+} ORDER BY ?item ?role {% if term_item_id %}?term {% endif %}?start ?end

--- a/lib/commons/builder/queries/legislative_index.rq.liquid
+++ b/lib/commons/builder/queries/legislative_index.rq.liquid
@@ -1,0 +1,30 @@
+SELECT DISTINCT ?legislature ?legislatureLabel ?country ?countryLabel ?adminArea ?adminAreaLabel ?adminAreaType ?adminAreaTypeLabel ?legislaturePost ?legislaturePostLabel ?numberOfSeats WHERE {
+  {
+    {% include 'select_admin_areas_for_country' %}
+  }
+
+  ?adminArea wdt:P194/wdt:P527? ?legislature .
+
+  VALUES ?legislatureType { wd:Q11204 wd:Q10553309 }
+  ?legislature wdt:P31/wdt:P279* ?legislatureType .
+  FILTER (?legislatureType != wd:Q11204 || NOT EXISTS { ?legislature wdt:P527 ?legislaturePart . ?legislaturePart  wdt:P31/wdt:P279* wd:Q10553309 })
+
+  # Attempt to find the position for members of the legislature
+  OPTIONAL {
+    # Both "has part" and "has parts of class" seem to be used; with the latter not in keeping with the draft model
+    ?legislature wdt:P527|wdt:P2670 ?legislaturePost .
+    ?legislaturePost wdt:P31/wdt:P279* wd:Q4164871 .
+    # Make sure positions are either legislators or councillors (and so exclude e.g. mayors)
+    FILTER EXISTS {
+      VALUES ?legislaturePostSuperType { wd:Q4175034 wd:Q708492 }
+      ?legislaturePost wdt:P279+ ?legislaturePostSuperType .
+    }
+  }
+  OPTIONAL {
+    ?legislature wdt:P1342 ?numberOfSeats .
+  }
+
+  # Remove legislatures that have ended
+  FILTER NOT EXISTS { ?legislature wdt:P576 ?legislatureEnd . FILTER (?legislatureEnd < NOW()) }
+  {% include 'label_service' %}
+} ORDER BY ?primarySort ?country ?adminAreaType ?legislature ?legislaturePost

--- a/lib/commons/builder/queries/legislative_index_terms.rq.liquid
+++ b/lib/commons/builder/queries/legislative_index_terms.rq.liquid
@@ -1,0 +1,22 @@
+SELECT DISTINCT
+  ?house ?houseLabel
+  ?legislature ?legislatureLabel
+  ?term ?termLabel
+  ?termStart ?termEnd
+WHERE {
+  VALUES ?house { {% for house in houses %}wd:{{ house }} {% endfor %}}
+  ?house (p:P361/ps:P361)* ?legislature .
+      ?baseTerm p:P31|p:P279 [ ps:P279|ps:P31 wd:Q15238777 ; pq:P642 ?legislature ] .
+      OPTIONAL { ?subTerm wdt:P31 ?baseTerm }
+
+  BIND(COALESCE(?subTerm, ?baseTerm) AS ?term)
+
+  OPTIONAL { ?term (wdt:P580|wdt:P571) ?termStart. }
+  OPTIONAL { ?term (wdt:P582|wdt:P576) ?termEnd. }
+  OPTIONAL { ?term (wdt:P155|wdt:P1365) ?termReplaces }
+  OPTIONAL { ?term (wdt:P156|wdt:P1366) ?termReplacedBy }
+
+  FILTER (!BOUND(?termEnd) || ?termEnd > NOW())
+  FILTER (!BOUND(?termReplacedBy))
+  {% include 'label_service' %}
+} ORDER BY ?termStart ?term

--- a/lib/commons/builder/queries/select_admin_areas_for_country.rq.liquid
+++ b/lib/commons/builder/queries/select_admin_areas_for_country.rq.liquid
@@ -1,0 +1,19 @@
+SELECT DISTINCT ?primarySort ?adminArea ?adminAreaType {
+  {
+    VALUES (?adminArea ?primarySort ?adminAreaType) { (wd:{{ country }} 1 wd:Q6256) }
+  } UNION {
+    # Find FLACSen of this country
+    ?adminArea wdt:P17 wd:{{ country }} ;
+          wdt:P31/wdt:P279* wd:Q10864048
+    VALUES (?primarySort ?adminAreaType) { (2 wd:Q10864048) }
+  } UNION {
+    # Find cities with populations of over 250k
+    ?adminArea wdt:P17 wd:{{ country }} ;
+       wdt:P31/wdt:P279* wd:Q515 ;
+       wdt:P1082 ?population .
+    FILTER (?population > 250000)
+    # Make sure the city is not also a FLACS
+    MINUS { ?adminArea wdt:P31/wdt:P279* wd:Q10864048 }
+    VALUES (?primarySort ?adminAreaType) { (3 wd:Q515) }
+  }
+} ORDER BY ?primarySort

--- a/lib/commons/builder/queries/term_condition.rq.liquid
+++ b/lib/commons/builder/queries/term_condition.rq.liquid
@@ -1,0 +1,1 @@
+{% if term_item_id %}?statement pq:P2937 wd:{{ term_item_id }} .{% endif -%}

--- a/lib/commons/builder/wikidata_queries.rb
+++ b/lib/commons/builder/wikidata_queries.rb
@@ -3,41 +3,6 @@
 require 'liquid'
 
 class WikidataQueries < Wikidata
-  def query_legislative(position_item_id:, house_item_id:, term_item_id: nil, start_date: nil, end_date: nil, **_rest)
-    templated_query('legislative',
-                    position_item_id: position_item_id,
-                    house_item_id: house_item_id,
-                    term_item_id: term_item_id,
-                    start_date: start_date,
-                    end_date: end_date)
-  end
-
-  def query_executive(executive_item_id:, positions:, **_rest)
-    templated_query('executive',
-                    executive_item_id: executive_item_id,
-                    position_item_ids: positions.map(&:position_item_id))
-  end
-
-  def select_admin_areas_for_country(country)
-    templated_query('select_admin_areas_for_country',
-                    country: country)
-  end
-
-  def query_legislative_index(country)
-    templated_query('legislative_index',
-                    country: country)
-  end
-
-  def query_legislative_index_terms(*houses)
-    templated_query('legislative_index_terms',
-                    houses: houses)
-  end
-
-  def query_executive_index(country)
-    templated_query('executive_index',
-                    country: country)
-  end
-
   class LangTag < Liquid::Tag
     def variable(prefix, lang_code, query = true)
       variable = "#{prefix}_#{lang_code.tr('-', '_')}"

--- a/lib/commons/builder/wikidata_queries.rb
+++ b/lib/commons/builder/wikidata_queries.rb
@@ -1,243 +1,99 @@
 # frozen_string_literal: true
 
+require 'liquid'
+
 class WikidataQueries < Wikidata
-  def date_condition(start_date, end_date)
-    return '' unless start_date
-    end_date ||= '9999-12-31'
-    <<~DATE_CONDITION
-      BIND(COALESCE(?start, "1000-01-01T00:00:00Z"^^xsd:dateTime) AS ?start_or_sentinel)
-      BIND(COALESCE(?end, "9999-12-31T00:00:00Z"^^xsd:dateTime) AS ?end_or_sentinel)
-      FILTER (?end_or_sentinel >= "#{start_date}"^^xsd:dateTime)
-      FILTER (?start_or_sentinel <= "#{end_date}"^^xsd:dateTime)
-  DATE_CONDITION
-  end
-
-  def term_condition(term_item_id)
-    return '' unless term_item_id
-    "?statement pq:P2937 wd:#{term_item_id} ."
-  end
-
-  # Use this to generate a `SERVICE wikibase:label` SPARQL pattern, for use in
-  # situations where you want a single label to help the humans that maintain
-  # a democratic commons repository. Do not use it for labels to be presented
-  # to end-users, as that needs potentially multiple language-tagged labels.
-  # For that, use `lang_select` and `lang_options`.
-  def label_service
-    languages_with_en = (['en'] + languages).uniq
-    "SERVICE wikibase:label { bd:serviceParam wikibase:language \"#{languages_with_en.join(',')}\". }"
-  end
-
   def query_legislative(position_item_id:, house_item_id:, term_item_id: nil, start_date: nil, end_date: nil, **_rest)
     unless !!term_item_id ^ !!(start_date and end_date)
       raise 'You must specify either a term item or a start and end date (and not both)'
     end
-    <<~SPARQL
-      SELECT ?statement
-             ?item #{lang_select}
-             ?party #{lang_select('party_name')}
-             ?district #{lang_select('district_name')}
-             ?role #{lang_select('role')}
-             ?role_superclass #{lang_select('role_superclass')}
-             ?start ?end ?facebook
-             ?org #{lang_select('org')} ?org_jurisdiction ?org_seat_count
-      WHERE {
-        BIND(wd:#{position_item_id} as ?role) .
-        BIND(wd:#{house_item_id} as ?org) .
-        #{lang_options('org', '?org')}
-        OPTIONAL {
-          ?org wdt:P1001 ?org_jurisdiction
-        }
-        OPTIONAL {
-          ?org wdt:P1342 ?org_seat_count
-        }
-        ?item p:P39 ?statement .
-        #{lang_options}
-        ?statement ps:P39 ?role .
-        #{lang_options('role', '?role')}
-        OPTIONAL {
-          ?role wdt:P279 ?role_superclass .
-          ?role_superclass wdt:P279+ wd:Q4175034
-          #{lang_options('role_superclass', '?role_superclass')}
-        }
-        #{term_condition(term_item_id)}
-        OPTIONAL { ?statement pq:P580 ?start }
-        OPTIONAL { ?statement pq:P582 ?end }
-        OPTIONAL {
-          ?statement pq:P768 ?district.
-          #{lang_options('district_name', '?district')}
-        }
-        OPTIONAL {
-          ?statement pq:P4100 ?party.
-          #{lang_options('party_name', '?party')}
-        }
-        OPTIONAL { ?item wdt:P2013 ?facebook }
-        #{date_condition(start_date, end_date)}
-      } ORDER BY ?item ?role #{term_item_id ? '?term ' : ''}?start ?end
-  SPARQL
+    templated_query('legislative',
+                    position_item_id: position_item_id,
+                    house_item_id: house_item_id,
+                    term_item_id: term_item_id,
+                    start_date: start_date,
+                    end_date: end_date)
   end
 
   def query_executive(executive_item_id:, positions:, **_rest)
-    space_separated_role_superclass = positions.map { |p| "wd:#{p.position_item_id}" }.join(' ')
-    <<~SPARQL
-      SELECT ?statement
-             ?item #{lang_select}
-             ?party #{lang_select('party_name')}
-             ?district #{lang_select('district_name')}
-             ?role #{lang_select('role')}
-             ?start ?end ?facebook
-             ?role_superclass #{lang_select('role_superclass')}
-             ?org #{lang_select('org')} ?org_jurisdiction
-      WHERE {
-        VALUES ?role_superclass { #{space_separated_role_superclass} }
-        BIND(wd:#{executive_item_id} AS ?org)
-        #{lang_options('org', '?org')}
-        OPTIONAL {
-          ?org wdt:P1001 ?org_jurisdiction
-        }
-        ?item p:P39 ?statement .
-        #{lang_options}
-        ?statement ps:P39 ?role .
-        #{lang_options('role', '?role')}
-        ?role wdt:P279* ?role_superclass .
-        #{lang_options('role_superclass', '?role_superclass')}
-        ?role wdt:P361 ?org .
-        OPTIONAL {
-          ?role p:P1001/ps:P1001 ?district .
-          #{lang_options('district_name', '?district')}
-        }
-        OPTIONAL { ?statement pq:P580 ?start }
-        OPTIONAL { ?statement pq:P582 ?end }
-        BIND(COALESCE(?end, "9999-12-31T00:00:00Z"^^xsd:dateTime) AS ?end_or_sentinel)
-        FILTER(?end_or_sentinel >= NOW())
-        # Find any current party membership:
-        OPTIONAL {
-          ?item p:P102 ?party_statement .
-          ?party_statement ps:P102 ?party .
-          #{lang_options('party_name', '?party')}
-          OPTIONAL { ?party_statement pq:P582 ?end_party }
-          BIND(COALESCE(?end_party, "9999-12-31T00:00:00Z"^^xsd:dateTime) AS ?party_end_or_sentinel)
-          FILTER(?party_end_or_sentinel >= NOW())
-        }
-        OPTIONAL { ?item wdt:P2013 ?facebook }
-      } ORDER BY ?item ?role ?district ?start ?end
-  SPARQL
+    templated_query('executive',
+                    executive_item_id: executive_item_id,
+                    position_item_ids: positions.map(&:position_item_id))
   end
 
   def select_admin_areas_for_country(country)
-    <<~SPARQL
-      SELECT DISTINCT ?primarySort ?adminArea ?adminAreaType {
-        {
-          VALUES (?adminArea ?primarySort ?adminAreaType) { (#{country} 1 wd:Q6256) }
-        } UNION {
-          # Find FLACSen of this country
-          ?adminArea wdt:P17 #{country} ;
-                wdt:P31/wdt:P279* wd:Q10864048
-          VALUES (?primarySort ?adminAreaType) { (2 wd:Q10864048) }
-        } UNION {
-          # Find cities with populations of over 250k
-          ?adminArea wdt:P17 #{country} ;
-             wdt:P31/wdt:P279* wd:Q515 ;
-             wdt:P1082 ?population .
-          FILTER (?population > 250000)
-          # Make sure the city is not also a FLACS
-          MINUS { ?adminArea wdt:P31/wdt:P279* wd:Q10864048 }
-          VALUES (?primarySort ?adminAreaType) { (3 wd:Q515) }
-        }
-      } ORDER BY ?primarySort
-    SPARQL
+    templated_query('select_admin_areas_for_country',
+                    country: country)
   end
 
   def query_legislative_index(country)
-    country = "wd:#{country}" unless country.start_with?('wd:')
-    <<~SPARQL
-      SELECT DISTINCT ?legislature ?legislatureLabel ?country ?countryLabel ?adminArea ?adminAreaLabel ?adminAreaType ?adminAreaTypeLabel ?legislaturePost ?legislaturePostLabel ?numberOfSeats WHERE {
-        {
-          #{select_admin_areas_for_country(country)}
-        }
-
-        ?adminArea wdt:P194/wdt:P527? ?legislature .
-
-        VALUES ?legislatureType { wd:Q11204 wd:Q10553309 }
-        ?legislature wdt:P31/wdt:P279* ?legislatureType .
-        FILTER (?legislatureType != wd:Q11204 || NOT EXISTS { ?legislature wdt:P527 ?legislaturePart . ?legislaturePart  wdt:P31/wdt:P279* wd:Q10553309 })
-
-        # Attempt to find the position for members of the legislature
-        OPTIONAL {
-          # Both "has part" and "has parts of class" seem to be used; with the latter not in keeping with the draft model
-          ?legislature wdt:P527|wdt:P2670 ?legislaturePost .
-          ?legislaturePost wdt:P31/wdt:P279* wd:Q4164871 .
-          # Make sure positions are either legislators or councillors (and so exclude e.g. mayors)
-          FILTER EXISTS {
-            VALUES ?legislaturePostSuperType { wd:Q4175034 wd:Q708492 }
-            ?legislaturePost wdt:P279+ ?legislaturePostSuperType .
-          }
-        }
-        OPTIONAL {
-          ?legislature wdt:P1342 ?numberOfSeats .
-        }
-
-        # Remove legislatures that have ended
-        FILTER NOT EXISTS { ?legislature wdt:P576 ?legislatureEnd . FILTER (?legislatureEnd < NOW()) }
-        #{label_service}
-      } ORDER BY ?primarySort ?country ?adminAreaType ?legislature ?legislaturePost
-    SPARQL
+    templated_query('legislative_index',
+                    country: country)
   end
 
   def query_legislative_index_terms(*houses)
-    houses = houses.map { |house| "wd:#{house}" }.join(' ')
-    <<~SPARQL
-      SELECT DISTINCT ?house ?houseLabel ?legislature ?legislatureLabel ?term ?termLabel ?termStart ?termEnd WHERE {
-        VALUES ?house { #{houses} }
-        ?house (p:P361/ps:P361)* ?legislature .
-            ?baseTerm p:P31|p:P279 [ ps:P279|ps:P31 wd:Q15238777 ; pq:P642 ?legislature ] .
-            OPTIONAL { ?subTerm wdt:P31 ?baseTerm }
-
-        BIND(COALESCE(?subTerm, ?baseTerm) AS ?term)
-
-        OPTIONAL { ?term (wdt:P580|wdt:P571) ?termStart. }
-        OPTIONAL { ?term (wdt:P582|wdt:P576) ?termEnd. }
-        OPTIONAL { ?term (wdt:P155|wdt:P1365) ?termReplaces }
-        OPTIONAL { ?term (wdt:P156|wdt:P1366) ?termReplacedBy }
-
-        FILTER (!BOUND(?termEnd) || ?termEnd > NOW())
-        FILTER (!BOUND(?termReplacedBy))
-        #{label_service}
-      } ORDER BY ?termStart ?term
-    SPARQL
+    templated_query('legislative_index_terms',
+                    houses: houses)
   end
 
   def query_executive_index(country)
-    country = "wd:#{country}" unless country.start_with?('wd:')
-    <<~SPARQL
-      SELECT DISTINCT ?executive ?executiveLabel ?adminArea ?adminAreaLabel ?adminAreaType ?adminAreaTypeLabel ?position ?positionLabel {
-        {
-          #{select_admin_areas_for_country(country)}
-        }
+    templated_query('executive_index',
+                    country: country)
+  end
 
-        OPTIONAL {
-          {
-            ?position p:P1001 [ wikibase:rank ?appliesToJurisdictionRank ; ps:P1001 ?adminArea ] ;
-              wdt:P31/wdt:P279* wd:Q4164871 .
-            FILTER (?appliesToJurisdictionRank != wikibase:DeprecatedRank)
-            FILTER EXISTS {
-              VALUES ?positionSuperclass { wd:Q2285706 wd:Q30461 }
-              ?position wdt:P279* ?positionSuperclass .
-            }
-          } UNION {
-            ?adminArea wdt:P1313 ?position
-          }
+  class LangTag < Liquid::Tag
+    def variable(prefix, lang_code, query = true)
+      variable = "#{prefix}_#{lang_code.tr('-', '_')}"
+      variable = "?#{variable}" if query
+      variable
+    end
+  end
 
+  class LangSelect < LangTag
+    def initialize(_tag_name, prefix, options)
+      @prefix = Liquid::Variable.new(prefix, options)
+    end
+
+    def render(context)
+      context['languages'].map { |l| variable(@prefix.render(context), l) }.join(' ')
+    end
+  end
+
+  class LangOptions < LangTag
+    def initialize(_tag_name, params, options)
+      params = params.split
+      @prefix = Liquid::Variable.new(params[0], options)
+      @item = Liquid::Variable.new(params[1], options)
+    end
+
+    def render(context)
+      context['languages'].map do |l|
+        <<~CLAUSE
           OPTIONAL {
-            ?position wdt:P361 ?executive .
-            # Exclude executives that are privy councils
-            FILTER NOT EXISTS { ?executive wdt:P31/wdt:P279* wd:Q6528244 }
-            # Exclude executives which aren't direct parents of the position
-            FILTER NOT EXISTS { ?position wdt:P361 ?other . ?other wdt:P361+ ?executive }
+            #{@item.render(context)} rdfs:label #{variable(@prefix.render(context), l)}
+            FILTER(LANG(#{variable(@prefix.render(context), l)}) = \"#{l}\")
           }
-        }
+        CLAUSE
+      end.join("\n")
+    end
+  end
 
-        #{label_service}
-      } ORDER BY ?primarySort ?country ?adminAreaType ?executive ?position
-    SPARQL
+  def templated_query_from_string(name, query, options = {})
+    Liquid::Template.file_system = Liquid::LocalFileSystem.new(Pathname.new(__dir__).join('queries'), '%s.rq.liquid')
+    Liquid::Template.register_tag('lang_select', LangSelect)
+    Liquid::Template.register_tag('lang_options', LangOptions)
+
+    @templated_queries ||= {}
+    @templated_queries[name] ||= Liquid::Template.parse(query, error_mode: :strict)
+
+    options = options.map { |k, v| [k.to_s, v] }.to_h
+    options['languages'] = languages
+    options['self'] = self
+
+    @templated_queries[name].render!(options)
+  end
+
+  def templated_query(name, options = {})
+    templated_query_from_string name, Pathname.new(__dir__).join('queries', name + '.rq.liquid').read, options
   end
 end

--- a/lib/commons/builder/wikidata_queries.rb
+++ b/lib/commons/builder/wikidata_queries.rb
@@ -4,9 +4,6 @@ require 'liquid'
 
 class WikidataQueries < Wikidata
   def query_legislative(position_item_id:, house_item_id:, term_item_id: nil, start_date: nil, end_date: nil, **_rest)
-    unless !!term_item_id ^ !!(start_date and end_date)
-      raise 'You must specify either a term item or a start and end date (and not both)'
-    end
     templated_query('legislative',
                     position_item_id: position_item_id,
                     house_item_id: house_item_id,

--- a/test/commons/builder/wikidata_queries_test.rb
+++ b/test/commons/builder/wikidata_queries_test.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class WikidataQueriesTest < Minitest::Test
+  def test_lang_select_expected_result
+    lang_options = WikidataQueries::LangSelect.parse('lang_select', "'name' ", nil, Liquid::ParseContext.new)
+    context_data = { 'languages' => %w[en es] }
+    context = Liquid::Context.new context_data
+    expected = '?name_en ?name_es'
+    assert_equal(expected, lang_options.render(context))
+  end
+
+  def test_lang_options_expected_result
+    lang_options = WikidataQueries::LangOptions.parse('lang_options', "'name' '?item' ", nil, Liquid::ParseContext.new)
+    context_data = { 'languages' => %w[en es] }
+    context = Liquid::Context.new context_data
+    expected = <<~CLAUSE
+      OPTIONAL {
+        ?item rdfs:label ?name_en
+        FILTER(LANG(?name_en) = "en")
+      }
+
+      OPTIONAL {
+        ?item rdfs:label ?name_es
+        FILTER(LANG(?name_es) = "es")
+      }
+    CLAUSE
+    assert_equal(expected, lang_options.render(context))
+  end
+
+  def test_lang_select_expected_result_in_render
+    languages = %w[en zh-tw]
+    wikidata_queries = WikidataQueries.new languages
+    template = "{% lang_select 'party' %}"
+    expected = '?party_en ?party_zh_tw'
+    assert_equal expected, wikidata_queries.templated_query_from_string('q1', template)
+  end
+
+  def test_lang_options_expected_result_in_render
+    languages = %w[en zh-tw]
+    wikidata_queries = WikidataQueries.new languages
+    template = "{% lang_options 'party_name' '?party' %}"
+    expected = <<~CLAUSE
+      OPTIONAL {
+        ?party rdfs:label ?party_name_en
+        FILTER(LANG(?party_name_en) = "en")
+      }
+
+      OPTIONAL {
+        ?party rdfs:label ?party_name_zh_tw
+        FILTER(LANG(?party_name_zh_tw) = "zh-tw")
+      }
+    CLAUSE
+    assert_equal expected, wikidata_queries.templated_query_from_string('q2', template)
+  end
+
+  def test_templated_query_with_sym_options
+    languages = %w[en es]
+    wikidata_queries = WikidataQueries.new languages
+    assert_equal 'abc', wikidata_queries.templated_query_from_string('q3', 'a{{ foo }}c', foo: 'b')
+  end
+
+  def test_templated_query_with_string_options
+    languages = %w[en es]
+    wikidata_queries = WikidataQueries.new languages
+    assert_equal 'abc', wikidata_queries.templated_query_from_string('q4', 'a{{ foo }}c', 'foo' => 'b')
+  end
+
+  def test_templated_query_has_languages_available
+    languages = %w[en es]
+    wikidata_queries = WikidataQueries.new languages
+    template = '{% for l in languages %}{{ l }}{% unless forloop.last %}, {% endunless %}{% endfor %}'
+    assert_equal 'en, es', wikidata_queries.templated_query_from_string('q5', template)
+  end
+end


### PR DESCRIPTION
This resolves #55, and should make #54 and #50 easier.