### PR TITLE
Pass config through query generation methods to templates

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -9,7 +9,7 @@ require 'rest-client'
 
 URL = 'https://query.wikidata.org/sparql'
 
-config = Config.new('config.json')
+config = Config.new_from_file('config.json')
 
 root_dir = Pathname.new('').dirname
 

--- a/bin/build
+++ b/bin/build
@@ -27,7 +27,7 @@ actions = if ARGV.empty?
             ARGV.clone
           end
 
-wikidata_labels = WikidataLabels.new(config.languages)
+wikidata_labels = WikidataLabels.new(config)
 
 boundaries_dir = Dir.exist?('boundaries/build') ? 'boundaries/build' : 'boundaries'
 boundary_data = BoundaryData.new(wikidata_labels, boundaries_dir: boundaries_dir)
@@ -47,7 +47,7 @@ boundary_position_ids = boundary_data.popolo_areas.map { |a| a[:associated_wikid
       raw_results_pathname = output_dir.join('query-results.json')
 
       if actions.include? 'update'
-        sparql_query = term.query(config.languages)
+        sparql_query = term.query(config)
         output_dir.join('query-used.rq').write(sparql_query)
 
         query_params = {

--- a/bin/generate_executive_index
+++ b/bin/generate_executive_index
@@ -8,9 +8,7 @@ require 'commons/builder'
 
 config = Config.new_from_file('config.json')
 
-executives = Executive.list(config.country_wikidata_id,
-                            config.languages,
-                            save_queries: true)
+executives = Executive.list(config, save_queries: true)
 
 open('executive/index.json', 'w') do |file|
   file.write(JSON.pretty_generate(executives.map(&:as_json)))

--- a/bin/generate_executive_index
+++ b/bin/generate_executive_index
@@ -6,7 +6,7 @@ require 'bundler/setup'
 require 'json'
 require 'commons/builder'
 
-config = Config.new('config.json')
+config = Config.new_from_file('config.json')
 
 executives = Executive.list(config.country_wikidata_id,
                             config.languages,

--- a/bin/generate_legislative_index
+++ b/bin/generate_legislative_index
@@ -6,7 +6,7 @@ require 'bundler/setup'
 require 'json'
 require 'commons/builder'
 
-config = Config.new('config.json')
+config = Config.new_from_file('config.json')
 
 legislatures = Legislature.list(config.country_wikidata_id,
                                 config.languages,

--- a/bin/generate_legislative_index
+++ b/bin/generate_legislative_index
@@ -8,9 +8,7 @@ require 'commons/builder'
 
 config = Config.new_from_file('config.json')
 
-legislatures = Legislature.list(config.country_wikidata_id,
-                                config.languages,
-                                save_queries: true)
+legislatures = Legislature.list(config, save_queries: true)
 
 open('legislative/index.json', 'w') do |file|
   file.write(JSON.pretty_generate(legislatures.map(&:as_json)))

--- a/lib/commons/builder/config.rb
+++ b/lib/commons/builder/config.rb
@@ -6,11 +6,13 @@ require 'pathname'
 class Config
   attr_reader :values
 
-  def initialize(file)
-    @values = JSON.parse(
-      Pathname.new(file).read,
-      symbolize_names: true
-    )
+  def initialize(values)
+    @values = values
+  end
+
+  def self.new_from_file(filename)
+    Config.new(JSON.parse(Pathname.new(filename).read,
+                          symbolize_names: true))
   end
 
   def languages

--- a/lib/commons/builder/config.rb
+++ b/lib/commons/builder/config.rb
@@ -29,4 +29,12 @@ class Config
   def country_wikidata_id
     @country_wikidata_id ||= values[:country_wikidata_id]
   end
+
+  def to_liquid
+    # These variables are available in liquid templates
+    {
+      'country_wikidata_id' => country_wikidata_id,
+      'languages' => languages,
+    }
+  end
 end

--- a/lib/commons/builder/current_executive.rb
+++ b/lib/commons/builder/current_executive.rb
@@ -7,10 +7,10 @@ class CurrentExecutive
 
   attr_accessor :executive
 
-  def query(languages)
-    WikidataQueries.new(languages).templated_query('executive',
-                                                   executive_item_id: executive.executive_item_id,
-                                                   positions: executive.positions.map(&:position_item_id))
+  def query(config)
+    WikidataQueries.new(config).templated_query('executive',
+                                                executive_item_id: executive.executive_item_id,
+                                                position_item_ids: executive.positions.map(&:position_item_id))
   end
 
   def output_relative

--- a/lib/commons/builder/executive.rb
+++ b/lib/commons/builder/executive.rb
@@ -23,10 +23,10 @@ class Executive < Branch
     @positions.map { |t| Position.new(branch: self, **t) }
   end
 
-  def self.list(country_id, languages, save_queries: false)
-    wikidata_queries = WikidataQueries.new(languages)
-    wikidata_labels = WikidataLabels.new(languages)
-    sparql_query = wikidata_queries.templated_query('executive_index', country: country_id)
+  def self.list(config, save_queries: false)
+    wikidata_queries = WikidataQueries.new(config)
+    wikidata_labels = WikidataLabels.new(config)
+    sparql_query = wikidata_queries.templated_query('executive_index')
 
     open('executive/index-query-used.rq', 'w').write(sparql_query) if save_queries
     executives = wikidata_queries.perform(sparql_query)

--- a/lib/commons/builder/legislative_term.rb
+++ b/lib/commons/builder/legislative_term.rb
@@ -12,13 +12,13 @@ class LegislativeTerm
 
   attr_accessor :legislature, :term_item_id, :start_date, :end_date, :comment
 
-  def query(languages)
-    WikidataQueries.new(languages).templated_query('legislative',
-                                                   position_item_id: legislature.position_item_id,
-                                                   house_item_id: legislature.house_item_id,
-                                                   term_item_id: term_item_id,
-                                                   start_date: start_date,
-                                                   end_date: end_date)
+  def query(config)
+    WikidataQueries.new(config).templated_query('legislative',
+                                                position_item_id: legislature.position_item_id,
+                                                house_item_id: legislature.house_item_id,
+                                                term_item_id: term_item_id,
+                                                start_date: start_date,
+                                                end_date: end_date)
   end
 
   def output_relative

--- a/lib/commons/builder/legislature.rb
+++ b/lib/commons/builder/legislature.rb
@@ -17,9 +17,9 @@ class Legislature < Branch
     @terms.map { |t| LegislativeTerm.new(legislature: self, **t) }
   end
 
-  def self.list(country_id, languages, save_queries: false)
-    wikidata_queries = WikidataQueries.new(languages)
-    sparql_query = wikidata_queries.templated_query('legislative_index', country: country_id)
+  def self.list(config, save_queries: false)
+    wikidata_queries = WikidataQueries.new(config)
+    sparql_query = wikidata_queries.templated_query('legislative_index')
 
     open('legislative/index-query-used.rq', 'w').write(sparql_query) if save_queries
     legislatures = wikidata_queries.perform(sparql_query)

--- a/lib/commons/builder/queries/select_admin_areas_for_country.rq.liquid
+++ b/lib/commons/builder/queries/select_admin_areas_for_country.rq.liquid
@@ -1,14 +1,14 @@
 SELECT DISTINCT ?primarySort ?adminArea ?adminAreaType {
   {
-    VALUES (?adminArea ?primarySort ?adminAreaType) { (wd:{{ country }} 1 wd:Q6256) }
+    VALUES (?adminArea ?primarySort ?adminAreaType) { (wd:{{ config.country_wikidata_id }} 1 wd:Q6256) }
   } UNION {
     # Find FLACSen of this country
-    ?adminArea wdt:P17 wd:{{ country }} ;
+    ?adminArea wdt:P17 wd:{{ config.country_wikidata_id }} ;
           wdt:P31/wdt:P279* wd:Q10864048
     VALUES (?primarySort ?adminAreaType) { (2 wd:Q10864048) }
   } UNION {
     # Find cities with populations of over 250k
-    ?adminArea wdt:P17 wd:{{ country }} ;
+    ?adminArea wdt:P17 wd:{{ config.country_wikidata_id }} ;
        wdt:P31/wdt:P279* wd:Q515 ;
        wdt:P1082 ?population .
     FILTER (?population > 250000)

--- a/lib/commons/builder/wikidata.rb
+++ b/lib/commons/builder/wikidata.rb
@@ -3,11 +3,15 @@
 require 'rest-client'
 
 class Wikidata
-  attr_accessor :languages, :url
+  attr_accessor :config, :url
 
-  def initialize(languages, url: 'https://query.wikidata.org/sparql')
-    @languages = languages
+  def initialize(config, url: 'https://query.wikidata.org/sparql')
+    @config = config
     @url = url
+  end
+
+  def languages
+    config.languages
   end
 
   def perform(sparql_query)

--- a/lib/commons/builder/wikidata_queries.rb
+++ b/lib/commons/builder/wikidata_queries.rb
@@ -17,7 +17,7 @@ class WikidataQueries < Wikidata
     end
 
     def render(context)
-      context['languages'].map { |l| variable(@prefix.render(context), l) }.join(' ')
+      context['config']['languages'].map { |l| variable(@prefix.render(context), l) }.join(' ')
     end
   end
 
@@ -29,7 +29,7 @@ class WikidataQueries < Wikidata
     end
 
     def render(context)
-      context['languages'].map do |l|
+      context['config']['languages'].map do |l|
         <<~CLAUSE
           OPTIONAL {
             #{@item.render(context)} rdfs:label #{variable(@prefix.render(context), l)}
@@ -49,7 +49,7 @@ class WikidataQueries < Wikidata
     @templated_queries[name] ||= Liquid::Template.parse(query, error_mode: :strict)
 
     options = options.map { |k, v| [k.to_s, v] }.to_h
-    options['languages'] = languages
+    options['config'] = config
     options['self'] = self
 
     @templated_queries[name].render!(options)

--- a/test/commons/builder/config_test.rb
+++ b/test/commons/builder/config_test.rb
@@ -4,23 +4,28 @@ require 'test_helper'
 
 module Commons
   class ConfigTest < Minitest::Test
-    def test_can_access_json_values
-      config = Config.new('test/fixtures/config/config.json')
-      assert_equal('Q23666', config.values[:country_wikidata_id])
-    end
-
-    def test_can_access_languages
-      config = Config.new('test/fixtures/config/config.json')
+    def test_can_access_values_from_hash
+      config = Config.new languages: %w[en es]
       assert_equal(%w[en es], config.languages)
     end
 
-    def test_can_access_country_wikidata_id
-      config = Config.new('test/fixtures/config/config.json')
+    def test_can_access_json_values_from_file
+      config = Config.new_from_file('test/fixtures/config/config.json')
+      assert_equal('Q23666', config.values[:country_wikidata_id])
+    end
+
+    def test_can_access_languages_from_file
+      config = Config.new_from_file('test/fixtures/config/config.json')
+      assert_equal(%w[en es], config.languages)
+    end
+
+    def test_can_access_country_wikidata_id_from_file
+      config = Config.new_from_file('test/fixtures/config/config.json')
       assert_equal('Q23666', config.country_wikidata_id)
     end
 
     def test_can_infer_languages_from_language_map
-      config = Config.new('test/fixtures/config/config-with-language-map.json')
+      config = Config.new_from_file('test/fixtures/config/config-with-language-map.json')
       assert_equal(%w[en es], config.languages)
     end
   end

--- a/test/commons/builder/current_executive_test.rb
+++ b/test/commons/builder/current_executive_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class CurrentExecutiveTest < Minitest::Test
+  def test_current_executive_query_contains_position
+    config = Config.new languages: %w[en es], country_wikidata_id: 'Q16'
+
+    executive = Executive.new comment:           'Test Executive',
+                              executive_item_id: 'Q1',
+                              positions:         [{ position_item_id: 'Q1234', comment: 'Test position' }]
+
+    query = executive.terms[0].query(config)
+    assert_match(/\Wwd:Q1234\W/, query)
+  end
+end

--- a/test/commons/builder/executive_test.rb
+++ b/test/commons/builder/executive_test.rb
@@ -3,6 +3,11 @@
 require 'test_helper'
 
 class ExecutiveTest < Minitest::Test
+  def config(languages: ['en'])
+    data = { 'languages': languages, 'country_wikidata_id': 'Q16' }
+    Config.new(data)
+  end
+
   def test_as_json_round_trip
     data = {
       comment:           'Test Executive',
@@ -20,8 +25,7 @@ class ExecutiveTest < Minitest::Test
     stub_request(:post, 'https://query.wikidata.org/sparql')
       .to_return(body: open('test/fixtures/executive-index.srj', 'r'))
 
-    languages = ['en']
-    executives = Executive.list('Q16', languages)
+    executives = Executive.list(config)
     assert_equal 3, executives.length
     assert_equal "Queen's Privy Council for Canada", executives[0].comment
     assert_equal 'Q1631137', executives[0].executive_item_id
@@ -35,8 +39,7 @@ class ExecutiveTest < Minitest::Test
       .to_return(body: open('test/fixtures/executive-index-missing-executive.srj', 'r')).then
       .to_return(body: '[]')
 
-    languages = ['en']
-    executives = Executive.list('Q16', languages)
+    executives = Executive.list(config)
     assert_equal [], executives
   end
 
@@ -45,8 +48,7 @@ class ExecutiveTest < Minitest::Test
       .to_return(body: open('test/fixtures/executive-index-missing-position.srj', 'r')).then
       .to_return(body: '[]')
 
-    languages = ['en']
-    executives = Executive.list('Q16', languages)
+    executives = Executive.list(config)
     assert_equal [], executives
   end
 end

--- a/test/commons/builder/legislative_term_test.rb
+++ b/test/commons/builder/legislative_term_test.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class LegislativeTermTest < Minitest::Test
+  def test_legislative_term_query_contains_position_item_id
+    config = Config.new languages: %w[en es], country_wikidata_id: 'Q16'
+    term = { comment: 'Term', term_item_id: 'Q3' }
+    legislature = Legislature.new(terms: [term], house_item_id: 'Q1',
+                                  position_item_id: 'Q1234', comment: 'Test legislature')
+    query = legislature.terms[0].query(config)
+    assert_match(/\Wwd:Q1234\W/, query)
+  end
+end

--- a/test/commons/builder/wikidata_queries_test.rb
+++ b/test/commons/builder/wikidata_queries_test.rb
@@ -3,9 +3,14 @@
 require 'test_helper'
 
 class WikidataQueriesTest < Minitest::Test
+  def config(languages: ['en'])
+    data = { 'languages': languages, 'country_wikidata_id': 'Q16' }
+    Config.new(data)
+  end
+
   def test_lang_select_expected_result
     lang_options = WikidataQueries::LangSelect.parse('lang_select', "'name' ", nil, Liquid::ParseContext.new)
-    context_data = { 'languages' => %w[en es] }
+    context_data = { 'config' => config(languages: %w[en es]) }
     context = Liquid::Context.new context_data
     expected = '?name_en ?name_es'
     assert_equal(expected, lang_options.render(context))
@@ -13,7 +18,7 @@ class WikidataQueriesTest < Minitest::Test
 
   def test_lang_options_expected_result
     lang_options = WikidataQueries::LangOptions.parse('lang_options', "'name' '?item' ", nil, Liquid::ParseContext.new)
-    context_data = { 'languages' => %w[en es] }
+    context_data = { 'config' => config(languages: %w[en es]) }
     context = Liquid::Context.new context_data
     expected = <<~CLAUSE
       OPTIONAL {
@@ -31,7 +36,7 @@ class WikidataQueriesTest < Minitest::Test
 
   def test_lang_select_expected_result_in_render
     languages = %w[en zh-tw]
-    wikidata_queries = WikidataQueries.new languages
+    wikidata_queries = WikidataQueries.new config(languages: languages)
     template = "{% lang_select 'party' %}"
     expected = '?party_en ?party_zh_tw'
     assert_equal expected, wikidata_queries.templated_query_from_string('q1', template)
@@ -39,7 +44,7 @@ class WikidataQueriesTest < Minitest::Test
 
   def test_lang_options_expected_result_in_render
     languages = %w[en zh-tw]
-    wikidata_queries = WikidataQueries.new languages
+    wikidata_queries = WikidataQueries.new config(languages: languages)
     template = "{% lang_options 'party_name' '?party' %}"
     expected = <<~CLAUSE
       OPTIONAL {
@@ -57,20 +62,20 @@ class WikidataQueriesTest < Minitest::Test
 
   def test_templated_query_with_sym_options
     languages = %w[en es]
-    wikidata_queries = WikidataQueries.new languages
+    wikidata_queries = WikidataQueries.new config(languages: languages)
     assert_equal 'abc', wikidata_queries.templated_query_from_string('q3', 'a{{ foo }}c', foo: 'b')
   end
 
   def test_templated_query_with_string_options
     languages = %w[en es]
-    wikidata_queries = WikidataQueries.new languages
+    wikidata_queries = WikidataQueries.new config(languages: languages)
     assert_equal 'abc', wikidata_queries.templated_query_from_string('q4', 'a{{ foo }}c', 'foo' => 'b')
   end
 
   def test_templated_query_has_languages_available
     languages = %w[en es]
-    wikidata_queries = WikidataQueries.new languages
-    template = '{% for l in languages %}{{ l }}{% unless forloop.last %}, {% endunless %}{% endfor %}'
+    wikidata_queries = WikidataQueries.new config(languages: languages)
+    template = '{% for l in config.languages %}{{ l }}{% unless forloop.last %}, {% endunless %}{% endfor %}'
     assert_equal 'en, es', wikidata_queries.templated_query_from_string('q5', template)
   end
 end

--- a/test/commons/builder/wikidata_test.rb
+++ b/test/commons/builder/wikidata_test.rb
@@ -4,29 +4,33 @@ require 'test_helper'
 
 module Commons
   class WikidataTest < Minitest::Test
-    def test_accepts_languages
-      languages = ['en']
-      wikidata = Wikidata.new(languages)
-      assert_equal(languages, wikidata.languages)
+    def config(languages: ['en'])
+      data = { 'languages': languages, 'country_wikidata_id': 'Q16' }
+      Config.new(data)
+    end
+
+    def test_accepts_config
+      wikidata = Wikidata.new config(languages: %w[en es])
+      assert_equal(%w[en es], wikidata.languages)
     end
 
     def test_lang_select_returns_space_delimited_names
       languages = ['en']
-      wikidata = Wikidata.new(languages)
+      wikidata = Wikidata.new config(languages: languages)
       expected = '?name_en'
       assert_equal(expected, wikidata.lang_select)
     end
 
     def test_lang_select_converts_hypens
       languages = ['zh-tw']
-      wikidata = Wikidata.new(languages)
+      wikidata = Wikidata.new config(languages: languages)
       expected = '?name_zh_tw'
       assert_equal(expected, wikidata.lang_select)
     end
 
     def test_lang_options_returns_optional_filter
       languages = ['en']
-      wikidata = Wikidata.new(languages)
+      wikidata = Wikidata.new config(languages: languages)
       expected = <<~OPTIONAL_CLAUSE
         OPTIONAL {
                   ?item rdfs:label ?name_en
@@ -38,7 +42,7 @@ module Commons
 
     def test_lang_options_converts_hypens
       languages = ['zh-tw']
-      wikidata = Wikidata.new(languages)
+      wikidata = Wikidata.new config(languages: languages)
       expected = <<~OPTIONAL_CLAUSE
         OPTIONAL {
                   ?item rdfs:label ?name_zh_tw

--- a/test/commons/legislative_index_test.rb
+++ b/test/commons/legislative_index_test.rb
@@ -8,6 +8,11 @@ require 'commons/builder/legislative_term'
 
 module Commons
   class LegislativeIndexTest < Minitest::Test
+    def config(languages: ['en'])
+      data = { 'languages': languages, 'country_wikidata_id': 'Q16' }
+      Config.new(data)
+    end
+
     def test_legislative_term_item_as_json
       term = LegislativeTerm.new({ legislature: nil, term_item_id: 'Q123', comment: 'Test term' })
       assert_equal term.as_json, {
@@ -45,8 +50,7 @@ module Commons
         .to_return(body: open('test/fixtures/legislative-index-terms.srj', 'r'))
 
       Timecop.freeze(Date.new(2010, 0o1, 0o1)) do
-        languages = ['en']
-        legislatures = Legislature.list('Q16', languages)
+        legislatures = Legislature.list(config)
         assert_equal 'Senate of Canada', legislatures[0].comment
         assert_equal LegislativeTerm.new(legislature: legislatures[0],
                                          term_item_id: 'Q21157957',


### PR DESCRIPTION
This will support adding more parameters to the config which can then be used to inform query generation, such as overriding regional administrative area Wikidata type IDs, and population thresholds (as requested in #54).