### PR TITLE
Fix regression: only 'en' was appearing in label service template output

### DIFF
--- a/lib/commons/builder/queries/label_service.rq.liquid
+++ b/lib/commons/builder/queries/label_service.rq.liquid
@@ -6,6 +6,6 @@
   For that, use `lang_select` and `lang_options`.
 {% endcomment -%}
 SERVICE wikibase:label { bd:serviceParam wikibase:language "en
-  {%- for language in languages %}
+  {%- for language in config.languages %}
     {%- if language != "en" %},{{ language }}{% endif %}
   {%- endfor %}". }

--- a/test/commons/builder/wikidata_queries_test.rb
+++ b/test/commons/builder/wikidata_queries_test.rb
@@ -78,4 +78,12 @@ class WikidataQueriesTest < Minitest::Test
     template = '{% for l in config.languages %}{{ l }}{% unless forloop.last %}, {% endunless %}{% endfor %}'
     assert_equal 'en, es', wikidata_queries.templated_query_from_string('q5', template)
   end
+
+  def test_label_service_has_all_langs
+    languages = %w[es en zh-tw]
+    wikidata_queries = WikidataQueries.new config(languages: languages)
+    template = "{% include 'label_service' %}"
+    expected = 'SERVICE wikibase:label { bd:serviceParam wikibase:language "en,es,zh-tw". }'
+    assert_equal expected, wikidata_queries.templated_query_from_string('q5', template)
+  end
 end


### PR DESCRIPTION
The regression was introduced in 9fb0986 when `languages` was removed from the context and replaced with `config`, making `languages` available as `config.languages`, without updating `lib/commons/builder/queries/label_service.rq.liquid`.

Added a regression test, but we should also ensure that in general attempting to access variables not in the context should raise an exception.

Closes #59.