### PR TITLE
Ensure branch person queries always return real people

### DIFF
--- a/lib/commons/builder/queries/executive.rq.liquid
+++ b/lib/commons/builder/queries/executive.rq.liquid
@@ -13,7 +13,8 @@ WHERE {
   OPTIONAL {
     ?org wdt:P1001 ?org_jurisdiction
   }
-  ?item p:P39 ?statement .
+  ?item wdt:P31 wd:Q5 ;
+        p:P39 ?statement .
   {% lang_options 'name' '?item' %}
   ?statement ps:P39 ?role .
   {% lang_options 'role' '?role' %}

--- a/lib/commons/builder/queries/legislative.rq.liquid
+++ b/lib/commons/builder/queries/legislative.rq.liquid
@@ -16,7 +16,8 @@ WHERE {
   OPTIONAL {
     ?org wdt:P1342 ?org_seat_count
   }
-  ?item p:P39 ?statement .
+  ?item wdt:P31 wd:Q5 ;
+        p:P39 ?statement .
   {% lang_options 'name' '?item' %}
   ?statement ps:P39 ?role .
   {% lang_options 'role' '?role' %}

--- a/test/commons/builder/wikidata_queries_test.rb
+++ b/test/commons/builder/wikidata_queries_test.rb
@@ -94,4 +94,15 @@ class WikidataQueriesTest < Minitest::Test
     assert_match(/\(wd:Q1234 4 wd:Q24238356\)\s+\(wd:Q1235 4 wd:Q24238356\)/,
                  wikidata_queries.templated_query('select_admin_areas_for_country'))
   end
+
+  def test_query_real_people
+    # Ensure branch person queries always return humans (and not e.g. fictional humans)
+    wikidata_queries = WikidataQueries.new Config.new(languages: ['en'],
+                                                      country_wikidata_id: 'Q16',
+                                                      additional_admin_area_ids: %w[Q1234 Q1235])
+    assert_match(/\?item\s+wdt:P31\s+wd:Q5/,
+                 wikidata_queries.templated_query('executive'))
+    assert_match(/\?item\s+wdt:P31\s+wd:Q5/,
+                 wikidata_queries.templated_query('legislative'))
+  end
 end


### PR DESCRIPTION
Until now, it's been possible for fictional humans (e.g. fictional prime
ministers) to be returned.

Also tested on the UK, resulting in Harriet Jones no longer being included.

Closes #65.