### PR TITLE
Fetch rich position data for area-associated positions

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -35,6 +35,15 @@ wikidata_results_parser = WikidataResultsParser.new(languages: config.languages)
 boundaries_dir = Dir.exist?('boundaries/build') ? 'boundaries/build' : 'boundaries'
 boundary_data = BoundaryData.new(wikidata_labels, boundaries_dir: boundaries_dir)
 
+position_data = PositionData.new(
+  output_dir_pn: Pathname.new(boundaries_dir),
+  wikidata_client: wikidata_client,
+  config: config
+)
+
+position_data.update if actions.include? 'update'
+position_data.build if actions.include? 'build'
+
 boundary_position_ids = boundary_data.popolo_areas.map { |a| a[:associated_wikidata_positions] }.flatten.to_set
 
 %w[legislative executive].each do |political_entity_kind|

--- a/lib/commons/builder.rb
+++ b/lib/commons/builder.rb
@@ -18,6 +18,7 @@ require 'commons/builder/wikidata_queries'
 require 'commons/builder/wikidata_results_parser'
 require 'commons/builder/wikidata_results'
 require 'commons/builder/query'
+require 'commons/builder/position_data'
 
 module Commons
   module Builder

--- a/lib/commons/builder/position_data.rb
+++ b/lib/commons/builder/position_data.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+class PositionData
+  def initialize(output_dir_pn:, wikidata_client:, config:)
+    @output_dir_pn = output_dir_pn
+    @wikidata_client = wikidata_client
+    @config = config
+  end
+
+  def update
+    query.run(wikidata_client: wikidata_client)
+  end
+
+  def build
+    position_data = parsed_data.map do |wd_row|
+      {
+        role_id: wd_row[:position].value,
+        role_name: wd_row.name_object('position_name'),
+        generic_role_id: wd_row[:positionSuperclass].value,
+        generic_role_name: wd_row.name_object('position_superclass'),
+        role_level: wd_row[:adminAreaTypes].value,
+        role_type: wd_row[:positionType]&.value,
+        organization_id: wd_row[:legislature].value,
+        organization_name: wd_row.name_object('legislature'),
+      }
+    end
+    # There might be multiple generic_roles (e.g. President of Brazil is
+    # sublassed both from 'head of government' and 'president') but we
+    # don't need both. Sort predictably but arbitrarily and pick the
+    # first of those:
+    deduplicated = position_data.group_by { |e| e[:role_id] }.values.map do |roles|
+      roles.sort_by { |r| r[:generic_role_id] }[0]
+    end
+    # Now write it to disk:
+    output_dir_pn.join('position-data.json').write(
+      JSON.pretty_generate(deduplicated) + "\n"
+    )
+  end
+
+  private
+
+  attr_reader :output_dir_pn, :wikidata_client, :config
+
+  def parser
+    WikidataResultsParser.new(languages: config.languages)
+  end
+
+  def parsed_data
+    parser.parse(query.query_results_pn.read)
+  end
+
+  def sparql_query
+    @sparql_query ||= WikidataQueries.new(config).templated_query('information_from_positions')
+  end
+
+  def query
+    @query ||= Query.new(
+      sparql_query: sparql_query,
+      output_dir_pn: output_dir_pn,
+      output_fname_prefix: 'position-data-'
+    )
+  end
+end

--- a/lib/commons/builder/queries/information_from_positions.rq.liquid
+++ b/lib/commons/builder/queries/information_from_positions.rq.liquid
@@ -1,0 +1,30 @@
+SELECT DISTINCT
+  ?position {% lang_select 'position_name' %}
+  ?positionType
+  ?adminAreaTypes
+  ?adminArea {% lang_select 'admin_area' %}
+  ?positionSuperclass {% lang_select 'position_superclass' %}
+  ?body {% lang_select 'body' %}
+WHERE {
+  {
+    {% include 'select_admin_areas_for_country' %}
+  }
+  {% lang_options 'position_name' '?position' %}
+  ?body wdt:P527|wdt:P2670 ?position .
+  MINUS { ?body wdt:P576|wdt:P582 ?bodyEnd . FILTER(?bodyEnd < NOW()) }
+  {% lang_options 'body' '?body' %}
+  ?body wdt:P1001 ?adminArea .
+  {% lang_options 'admin_area' '?adminArea' %}
+  OPTIONAL {
+    # If this position appears to be legislative (it's an subclass* of 'legislator')
+    # populate ?positionType with that:
+    VALUES ?positionType { wd:Q4175034 }
+    ?position wdt:P279* ?positionType
+  }
+  # Add the immediate superclass of the position on its way to legislator, head of
+  # government or president:
+  VALUES ?positionAncestor { wd:Q4175034 wd:Q2285706 wd:Q30461  }
+  ?position wdt:P279 ?positionSuperclass .
+            ?positionSuperclass wdt:P279* ?positionAncestor .
+  {% lang_options 'position_superclass' '?positionSuperclass' %}
+} ORDER BY ?position

--- a/test/commons/builder/position_data_test.rb
+++ b/test/commons/builder/position_data_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class PositionDataTest < Minitest::Test
+  def example_response_body
+    @example_response_body ||= Pathname.new('test/fixtures/brazil-position-data.srj').read
+  end
+
+  def expected_parsed_data
+    [
+      {
+        role_id: 'Q18964326',
+        role_name: { 'lang:en': 'Member of the Senate of Brazil' },
+        generic_role_id: 'Q15686806',
+        generic_role_name: { 'lang:pt': 'senador', 'lang:en': 'senator' },
+        role_level: 'Q6256',
+        role_type: 'Q4175034',
+        organization_id: 'Q2119413',
+        organization_name: { 'lang:pt': 'Senado Federal do Brasil',
+                             'lang:en': 'Federal Senate of Brazil', },
+      },
+      { role_id: 'Q24255165',
+        role_name: { 'lang:pt': 'Prefeito de São Paulo', 'lang:en': 'Mayor of São Paulo' },
+        generic_role_id: 'Q30185',
+        generic_role_name: { 'lang:pt': 'prefeito', 'lang:en': 'mayor' },
+        role_level: 'Q15284 Q515',
+        role_type: nil,
+        organization_id: 'Q10351100',
+        organization_name: { 'lang:pt': 'Prefeitura do Município de São Paulo',
+                             'lang:en': 'municipal prefecture of São Paulo', }, },
+    ]
+  end
+
+  def test_update
+    mock_client = MiniTest::Mock.new
+    mock_client.expect(:perform_raw, example_response_body, [String])
+    Dir.mktmpdir do |tmpdir|
+      tmpdir_pn = Pathname.new(tmpdir)
+      position_data = PositionData.new(
+        output_dir_pn: tmpdir_pn,
+        wikidata_client: mock_client,
+        config: Config.new(languages: %w[pt en], country_wikidata_id: 'Q155')
+      )
+      position_data.update
+      assert_equal example_response_body, tmpdir_pn.join('position-data-query-results.json').read
+    end
+    mock_client.verify
+  end
+
+  def test_build
+    Dir.mktmpdir do |tmpdir|
+      tmpdir_pn = Pathname.new(tmpdir)
+      tmpdir_pn.join('position-data-query-results.json').write(example_response_body)
+      position_data = PositionData.new(
+        output_dir_pn: tmpdir_pn,
+        wikidata_client: nil,
+        config: Config.new(languages: %w[pt en], country_wikidata_id: 'Q155')
+      )
+      position_data.build
+      assert_equal(
+        expected_parsed_data,
+        JSON.parse(tmpdir_pn.join('position-data.json').read, symbolize_names: true)
+      )
+    end
+  end
+end

--- a/test/fixtures/brazil-position-data.srj
+++ b/test/fixtures/brazil-position-data.srj
@@ -1,0 +1,129 @@
+{
+  "head" : {
+    "vars" : [ "position", "position_name_pt", "position_name_en", "positionType", "adminAreaTypes", "adminArea", "admin_area_pt", "admin_area_en", "positionSuperclass", "position_superclass_pt", "position_superclass_en", "legislature", "legislature_pt", "legislature_en" ]
+  },
+  "results" : {
+    "bindings" : [ {
+      "position" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q18964326"
+      },
+      "position_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of the Senate of Brazil"
+      },
+      "positionType" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q4175034"
+      },
+      "adminAreaTypes" : {
+        "type" : "literal",
+        "value" : "Q6256"
+      },
+      "adminArea" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q155"
+      },
+      "admin_area_pt" : {
+        "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Brasil"
+      },
+      "admin_area_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Brazil"
+      },
+      "positionSuperclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15686806"
+      },
+      "position_superclass_pt" : {
+        "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "senador"
+      },
+      "position_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "senator"
+      },
+      "legislature" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q2119413"
+      },
+      "legislature_pt" : {
+        "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Senado Federal do Brasil"
+      },
+      "legislature_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Federal Senate of Brazil"
+      }
+    }, {
+      "position" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q24255165"
+      },
+      "position_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Mayor of São Paulo"
+      },
+      "adminAreaTypes" : {
+        "type" : "literal",
+        "value" : "Q15284 Q515"
+      },
+      "adminArea" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q174"
+      },
+      "admin_area_pt" : {
+        "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "São Paulo"
+      },
+      "admin_area_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "São Paulo"
+      },
+      "positionSuperclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q30185"
+      },
+      "position_superclass_pt" : {
+        "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "prefeito"
+      },
+      "position_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "mayor"
+      },
+      "legislature" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q10351100"
+      },
+      "legislature_pt" : {
+        "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Prefeitura do Município de São Paulo"
+      },
+      "legislature_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "municipal prefecture of São Paulo"
+      },
+      "position_name_pt" : {
+        "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Prefeito de São Paulo"
+      }
+    } ]
+  }
+}


### PR DESCRIPTION
In the downstream build, we need to be able to show for each area the
positions that are associated with it - not just the position item ID
(available from boundaries/build/index.json) but also what level it's at
(national, regional, local), what chamber or organization it's
associated with (e.g. a cabinet, a legislature), and whether it's an
executive or legislative position.
    
The results of us querying Wikidata for members of these positions will
bring in some of this data (and could be extended to the rest) but that
will only be for areas where we know who the representatives are. That's
not good enough - we should have a complete record of the areas we're
concerned with from the country from the data under boundaries/ and we
need to find this rich position data for each of those.
    
This commit adds an extra step to `update` and `build` to fetch and
parse this richer position data for each area found in the boundary data.
    
(Note that this will likely make some countries fail `build check`, but
that's a good thing - we need to update the boundary data index so that
this data *is* complete.)
