### PR TITLE
Allow regional admin area type to be overridden from FLACS

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ legislatures and executives, then add a `additional_admin_area_ids` key:
 }
 ```
 
+If the regional administrative admin areas you want aren't FLACSen, use
+`regional_admin_area_type_id` to specify the Wikidata ID of the superclass you
+want to use.
+
 Create the directory structure and `index.json` files in each, each containing
 an empty array to be populated later:
 

--- a/lib/commons/builder/config.rb
+++ b/lib/commons/builder/config.rb
@@ -30,6 +30,10 @@ class Config
     @country_wikidata_id ||= values[:country_wikidata_id]
   end
 
+  def regional_admin_area_type_id
+    values[:regional_admin_area_type_id] || 'Q10864048' # default to FLACS
+  end
+
   def additional_admin_area_ids
     @additional_admin_area_ids ||= values[:additional_admin_area_ids] || []
   end
@@ -40,6 +44,7 @@ class Config
       'additional_admin_area_ids' => additional_admin_area_ids,
       'country_wikidata_id' => country_wikidata_id,
       'languages' => languages,
+      'regional_admin_area_type_id' => regional_admin_area_type_id,
     }
   end
 end

--- a/lib/commons/builder/queries/select_admin_areas_for_country.rq.liquid
+++ b/lib/commons/builder/queries/select_admin_areas_for_country.rq.liquid
@@ -4,10 +4,10 @@ SELECT DISTINCT ?adminArea
   {
     VALUES (?adminArea ?primarySort ?adminAreaType) { (wd:{{ config.country_wikidata_id }} 1 wd:Q6256) }
   } UNION {
-    # Find FLACSen of this country
+    # Find regional admin areas of this country (generally FLACSen)
     ?adminArea wdt:P17 wd:{{ config.country_wikidata_id }} ;
-          wdt:P31/wdt:P279* wd:Q10864048
-    VALUES (?primarySort ?adminAreaType) { (2 wd:Q10864048) }
+          wdt:P31/wdt:P279* wd:{{ config.regional_admin_area_type_id }}
+    VALUES (?primarySort ?adminAreaType) { (2 wd:{{ config.regional_admin_area_type_id }}) }
   } UNION {
     # Find cities or municipalities with populations of over 250k
     VALUES ?adminAreaType { wd:Q515 wd:Q15284 }

--- a/test/commons/builder/wikidata_queries_test.rb
+++ b/test/commons/builder/wikidata_queries_test.rb
@@ -95,6 +95,14 @@ class WikidataQueriesTest < Minitest::Test
                  wikidata_queries.templated_query('select_admin_areas_for_country'))
   end
 
+  def test_override_regional_admin_area_type_id
+    wikidata_queries = WikidataQueries.new Config.new(languages: ['en'],
+                                                      country_wikidata_id: 'Q16',
+                                                      regional_admin_area_type_id: 'Q953822')
+    assert_match(%r{\?adminArea[^.]+wdt:P31/wdt:P279\*\s+wd:Q953822},
+                 wikidata_queries.templated_query('select_admin_areas_for_country'))
+  end
+
   def test_query_real_people
     # Ensure branch person queries always return humans (and not e.g. fictional humans)
     wikidata_queries = WikidataQueries.new Config.new(languages: ['en'],


### PR DESCRIPTION
This goes half-way to addressing #53, the other half being the ability to override the use of a P17 relationship. It does however allow us to do Costa Rica, where we're interested in cantons, which aren't FLACSen.