### PR TITLE
Always use legislature position for exposed/serialized role.

### DIFF
--- a/lib/commons/builder/legislative_term.rb
+++ b/lib/commons/builder/legislative_term.rb
@@ -16,11 +16,16 @@ class LegislativeTerm
 
   def query(config)
     WikidataQueries.new(config).templated_query('legislative',
-                                                position_item_id: position_item_id || legislature.position_item_id,
+                                                position_item_id: legislature.position_item_id,
+                                                specific_position_item_id: specific_position_item_id,
                                                 house_item_id: legislature.house_item_id,
                                                 term_item_id: term_item_id,
                                                 start_date: start_date,
                                                 end_date: end_date)
+  end
+
+  def specific_position_item_id
+    position_item_id || legislature.position_item_id
   end
 
   def output_relative

--- a/lib/commons/builder/queries/legislative.rq.liquid
+++ b/lib/commons/builder/queries/legislative.rq.liquid
@@ -8,6 +8,7 @@ SELECT ?statement
        ?org {% lang_select 'org' %} ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:{{ position_item_id }} as ?role) .
+  BIND(wd:{{ specific_position_item_id }} as ?specific_role) .
   BIND(wd:{{ house_item_id }} as ?org) .
   {% lang_options 'org' '?org' %}
   OPTIONAL {
@@ -19,7 +20,7 @@ WHERE {
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
   {% lang_options 'name' '?item' %}
-  ?statement ps:P39 ?role .
+  ?statement ps:P39 ?specific_role .
   {% lang_options 'role' '?role' %}
   OPTIONAL {
     ?role wdt:P279 ?role_superclass .

--- a/test/commons/builder/legislative_term_test.rb
+++ b/test/commons/builder/legislative_term_test.rb
@@ -9,7 +9,8 @@ class LegislativeTermTest < Minitest::Test
     legislature = Legislature.new terms: [term], house_item_id: 'Q1',
                                   position_item_id: 'Q1234', comment: 'Test legislature'
     query = legislature.terms[0].query(config)
-    assert_match(/\Wwd:Q1234\W/, query)
+    assert_match(/\WBIND\(wd:Q1234 as \?role\)\W/, query)
+    assert_match(/\WBIND\(wd:Q1234 as \?specific_role\)\W/, query)
   end
 
   def test_legislative_term_query_contains_term_position_item_id
@@ -19,6 +20,7 @@ class LegislativeTermTest < Minitest::Test
     legislature = Legislature.new terms: [term], house_item_id: 'Q1',
                                   position_item_id: 'Q1234', comment: 'Test legislature'
     query = legislature.terms[0].query(config)
-    assert_match(/\Wwd:Q5678\W/, query)
+    assert_match(/\WBIND\(wd:Q1234 as \?role\)\W/, query)
+    assert_match(/\WBIND\(wd:Q5678 as \?specific_role\)\W/, query)
   end
 end


### PR DESCRIPTION
If there's a term-specific position, we should use it to find results, but
should still expose the generic position ID in results, to hide the vagaries of
there being a term-specific position.

This also means that the associated positions in the boundaries index can use
the generic position ID, and won't need updating every time a new term starts
(with its associated position).

Closes #76.