### PR TITLE
Collect seat counts for legislative terms

### DIFF
--- a/lib/commons/builder/legislative_term.rb
+++ b/lib/commons/builder/legislative_term.rb
@@ -2,17 +2,17 @@
 
 class LegislativeTerm
   def initialize(legislature:, term_item_id: nil, position_item_id: nil,
-                 start_date: nil, end_date: nil, comment: nil)
+                 start_date: nil, end_date: nil, **extra)
     raise 'You must specify a term item or a start and end date' if !term_item_id && !(start_date and end_date)
     @legislature = legislature
     @position_item_id = position_item_id
     @term_item_id = term_item_id
     @start_date = start_date
     @end_date = end_date
-    @comment = comment
+    @extra = extra
   end
 
-  attr_accessor :legislature, :term_item_id, :position_item_id, :start_date, :end_date, :comment
+  attr_accessor :legislature, :term_item_id, :position_item_id, :start_date, :end_date, :extra
 
   def query(config)
     WikidataQueries.new(config).templated_query('legislative',
@@ -38,14 +38,13 @@ class LegislativeTerm
 
   def ==(other)
     false unless other.instance_of? self.class
-    %i[legislature term_item_id start_date end_date comment position_item_id].all? do |name|
+    %i[legislature term_item_id start_date end_date extra position_item_id].all? do |name|
       send(name) == other.send(name)
     end
   end
 
   def as_json
-    result = {}
-    result[:comment] = @comment if @comment
+    result = extra.clone
     result[:position_item_id] = @position_item_id if @position_item_id
     if @term_item_id
       result[:term_item_id] = @term_item_id if @term_item_id

--- a/lib/commons/builder/legislature.rb
+++ b/lib/commons/builder/legislature.rb
@@ -73,6 +73,7 @@ class Legislature < Branch
       term[:start_date] = term_row[:termStart].value if term_row[:termStart]
       term[:end_date] = term_row[:termEnd].value if term_row[:termEnd]
       term[:position_item_id] = term_row[:termSpecificPosition].value if term_row[:termSpecificPosition]
+      term[:number_of_seats] = term_row[:numberOfSeats].value if term_row[:numberOfSeats]
 
       terms_by_legislature[term_row[:house].value]
       terms_by_legislature[term_row[:house].value].push(term)

--- a/lib/commons/builder/queries/legislative_index_terms.rq.liquid
+++ b/lib/commons/builder/queries/legislative_index_terms.rq.liquid
@@ -17,10 +17,13 @@ WHERE {
 
   BIND(COALESCE(?subTerm, ?baseTerm) AS ?term)
 
-  OPTIONAL { ?term (wdt:P580|wdt:P571) ?termStart. }
-  OPTIONAL { ?term (wdt:P582|wdt:P576) ?termEnd. }
-  OPTIONAL { ?term (wdt:P155|wdt:P1365) ?termReplaces }
-  OPTIONAL { ?term (wdt:P156|wdt:P1366) ?termReplacedBy }
+  OPTIONAL { ?term wdt:P582 ?termEndEndTime }
+  OPTIONAL { ?term wdt:P576 ?termEndDissolved }
+  BIND(COALESCE(?termEndEndTime, ?termEndDissolved) AS ?termEnd)
+
+  FILTER (!BOUND(?termEnd) || ?termEnd > NOW())
+  MINUS { ?term (wdt:P156|wdt:P1366) ?termReplacedBy }
+
   OPTIONAL {
     ?termSpecificPosition wdt:P31/wdt:P279* wd:Q4164871 ;
                           p:P279 [ ps:P279 ?position ;
@@ -30,8 +33,12 @@ WHERE {
   OPTIONAL {
     ?house p:P1342 ?numberOfSeatsHouseStatement .
     ?numberOfSeatsHouseStatement ps:P1342 ?numberOfSeatsHouse .
-    OPTIONAL { ?term (wdt:P580|wdt:P571) ?termStart }
-    OPTIONAL { ?term (wdt:P582|wdt:P576) ?termEnd }
+    OPTIONAL { ?term wdt:P580 ?termStartStartTime }
+    OPTIONAL { ?term wdt:P571 ?termStartInception }
+    BIND(COALESCE(?termStartStartTime, ?termStartInception) AS ?termStart)
+    OPTIONAL { ?term wdt:P582 ?termEndEndTime }
+    OPTIONAL { ?term wdt:P576 ?termEndDissolved }
+    BIND(COALESCE(?termEndEndTime, ?termEndDissolved) AS ?termEnd)
     OPTIONAL {
       ?numberOfSeatsHouseStatement pq:P580 ?numberOfSeatsHouseStatementStart .
     }
@@ -52,7 +59,5 @@ WHERE {
   }
   BIND(COALESCE(?numberOfSeatsTerm, ?numberOfSeatsHouse) AS ?numberOfSeats)
 
-  FILTER (!BOUND(?termEnd) || ?termEnd > NOW())
-  FILTER (!BOUND(?termReplacedBy))
   {% include 'label_service' %}
 } ORDER BY ?termStart ?term

--- a/lib/commons/builder/queries/legislative_index_terms.rq.liquid
+++ b/lib/commons/builder/queries/legislative_index_terms.rq.liquid
@@ -4,6 +4,7 @@ SELECT DISTINCT
   ?term ?termLabel
   ?termStart ?termEnd
   ?termSpecificPosition
+  ?numberOfSeats
 WHERE {
   VALUES (?house ?position) {
 {%- for house_position in house_positions %}
@@ -25,6 +26,31 @@ WHERE {
                           p:P279 [ ps:P279 ?position ;
                                    pq:P2937 ?term ] .
   }
+
+  OPTIONAL {
+    ?house p:P1342 ?numberOfSeatsHouseStatement .
+    ?numberOfSeatsHouseStatement ps:P1342 ?numberOfSeatsHouse .
+    OPTIONAL { ?term (wdt:P580|wdt:P571) ?termStart }
+    OPTIONAL { ?term (wdt:P582|wdt:P576) ?termEnd }
+    OPTIONAL {
+      ?numberOfSeatsHouseStatement pq:P580 ?numberOfSeatsHouseStatementStart .
+    }
+    OPTIONAL {
+      ?numberOfSeatsHouseStatement pq:P582 ?numberOfSeatsHouseStatementEnd .
+    }
+    FILTER (!(BOUND(?numberOfSeatsHouseStatementStart) && BOUND(?termStart) && (?numberOfSeatsHouseStatementStart > ?termStart)))
+    FILTER (!(BOUND(?numberOfSeatsHouseStatementEnd) && BOUND(?termEnd) && (?numberOfSeatsHouseStatementEnd < ?termEnd)))
+    FILTER (!(BOUND(?numberOfSeatsHouseStatementEnd) && BOUND(?termStart) && (?numberOfSeatsHouseStatementEnd < ?termStart)))
+  }
+  OPTIONAL {
+    ?term p:P1342 ?numberOfSeatsTermStatement .
+    ?numberOfSeatsTermStatement ps:P1342 ?numberOfSeatsTerm .
+    OPTIONAL {
+      ?numberOfSeatsTermStatement pq:P518 ?numberOfSeatsTermStatementAppliesToPart .
+    }
+    FILTER (!BOUND(?numberOfSeatsTermStatementAppliesToPart) || ?numberOfSeatsTermStatementAppliesToPart = ?house)
+  }
+  BIND(COALESCE(?numberOfSeatsTerm, ?numberOfSeatsHouse) AS ?numberOfSeats)
 
   FILTER (!BOUND(?termEnd) || ?termEnd > NOW())
   FILTER (!BOUND(?termReplacedBy))

--- a/test/commons/builder/legislative_index_test.rb
+++ b/test/commons/builder/legislative_index_test.rb
@@ -72,7 +72,8 @@ module Commons
                                          term_item_id: 'Q21157957',
                                          start_date: '2015-12-03',
                                          comment: '42nd Canadian Parliament',
-                                         position_item_id: 'Q30524710'), legislatures[2].terms[0]
+                                         position_item_id: 'Q30524710',
+                                         number_of_seats: 123), legislatures[2].terms[0]
 
         # This one has no term in the fixture data
         assert_equal 'Calgary City Council', legislatures[1].comment

--- a/test/commons/builder/legislative_term_test.rb
+++ b/test/commons/builder/legislative_term_test.rb
@@ -23,4 +23,13 @@ class LegislativeTermTest < Minitest::Test
     assert_match(/\WBIND\(wd:Q1234 as \?role\)\W/, query)
     assert_match(/\WBIND\(wd:Q5678 as \?specific_role\)\W/, query)
   end
+
+  def test_extra_serialization
+    # Any unknown parameters should be serialized verbatim
+    term = { comment: 'Term', term_item_id: 'Q3', position_item_id: 'Q5678',
+             number_of_seats: 5, building_name: 'Big Building', }
+    legislature = Legislature.new terms: [term], house_item_id: 'Q1',
+                                  position_item_id: 'Q1234', comment: 'Test legislature'
+    assert_equal term, legislature.terms[0].as_json
+  end
 end

--- a/test/fixtures/legislative-index-terms.srj
+++ b/test/fixtures/legislative-index-terms.srj
@@ -56,6 +56,12 @@
                     "xml:lang": "en",
                     "type": "literal",
                     "value": "Member of the 57th Parliament of the United Kingdom"
+                },
+                "numberOfSeats": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+                    "type": "literal",
+                    "value": 123
+
                 }
             },
             {
@@ -90,6 +96,12 @@
                     "xml:lang": "en",
                     "type": "literal",
                     "value": "29th Alberta Legislature"
+                },
+                "numberOfSeats": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#integer",
+                    "type": "literal",
+                    "value": 456
+
                 }
             }
         ]


### PR DESCRIPTION
Adds `number_of_seats` to legislative terms in the legislative index, where they can be deduced.

This will support presenting a % completion metric on commons-explorer, and closes #79.