### PR TITLE
Executive.list> handle one executive having multiple positions

### DIFF
--- a/lib/commons/builder/executive.rb
+++ b/lib/commons/builder/executive.rb
@@ -52,15 +52,19 @@ class Executive < Branch
 
       true
     end
+    executives_sorted = executives.sort_by { |row| row[:executive].value }
+    executives_grouped = executives_sorted.group_by { |row| [row[:executive].value, row[:executiveLabel]&.value] }
 
-    executives_unsorted = executives.map do |row|
-      new(comment:           row[:executiveLabel]&.value,
-          executive_item_id: row[:executive].value,
-          positions:         [{ comment:          row[:positionLabel]&.value,
-                                position_item_id: row[:position].value, },])
+    executives_grouped.map do |(executive_item_id, comment), rows|
+      new(
+        executive_item_id: executive_item_id,
+        comment:           comment,
+        positions:         rows.map do |row|
+          { comment:          row[:positionLabel]&.value,
+            position_item_id: row[:position].value, }
+        end
+      )
     end
-
-    executives_unsorted.sort_by { |h| [h.executive_item_id, h.positions] }
   end
 
   def as_json

--- a/test/commons/builder/executive_test.rb
+++ b/test/commons/builder/executive_test.rb
@@ -51,4 +51,17 @@ class ExecutiveTest < Minitest::Test
     executives = Executive.list(config)
     assert_equal [], executives
   end
+
+  def test_list_with_two_positions_for_one_executive
+    # If an executive is listed in the results more than once, with multiple positions, group those positions into a
+    # single executive entry. Also ensure that the entries are sorted by executive and position item IDs.
+    stub_request(:post, 'https://query.wikidata.org/sparql')
+      .to_return(body: open('test/fixtures/executive-index-two-positions.srj', 'r'))
+
+    executives = Executive.list(config)
+    assert_equal 2, executives.length
+    assert_equal 'Q2665914', executives[0].executive_item_id
+    assert_equal %w[Q22979263 Q23729452], executives[0].positions.map(&:position_item_id)
+    assert_equal 'Q32859621', executives[1].executive_item_id
+  end
 end

--- a/test/fixtures/executive-index-two-positions.srj
+++ b/test/fixtures/executive-index-two-positions.srj
@@ -1,0 +1,116 @@
+{
+    "head": {
+        "vars": [
+            "executive",
+            "executiveLabel",
+            "adminArea",
+            "adminAreaLabel",
+            "adminAreaTypes",
+            "position",
+            "positionLabel"
+        ]
+    },
+    "results": {
+        "bindings": [
+            {
+                "executive": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q2665914"
+                },
+                "executiveLabel": {
+                    "xml:lang": "en",
+                    "type": "literal",
+                    "value": "Northern Ireland Executive"
+                },
+                "adminArea": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q26"
+                },
+                "adminAreaLabel": {
+                    "xml:lang": "en",
+                    "type": "literal",
+                    "value": "Northern Ireland"
+                },
+                "adminAreaTypes": {
+                    "type": "literal",
+                    "value": "Q10864048"
+                },
+                "position": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q22979263"
+                },
+                "positionLabel": {
+                    "xml:lang": "en",
+                    "type": "literal",
+                    "value": "First Minister of Northern Ireland"
+                }
+            },
+            {
+                "executive": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q2665914"
+                },
+                "executiveLabel": {
+                    "xml:lang": "en",
+                    "type": "literal",
+                    "value": "Northern Ireland Executive"
+                },
+                "adminArea": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q26"
+                },
+                "adminAreaLabel": {
+                    "xml:lang": "en",
+                    "type": "literal",
+                    "value": "Northern Ireland"
+                },
+                "adminAreaTypes": {
+                    "type": "literal",
+                    "value": "Q10864048"
+                },
+                "position": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q23729452"
+                },
+                "positionLabel": {
+                    "xml:lang": "en",
+                    "type": "literal",
+                    "value": "deputy First Minister"
+                }
+            },
+            {
+                "executive": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q32859621"
+                },
+                "executiveLabel": {
+                    "xml:lang": "en",
+                    "type": "literal",
+                    "value": "Cabinet of Scotland"
+                },
+                "adminArea": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q22"
+                },
+                "adminAreaLabel": {
+                    "xml:lang": "en",
+                    "type": "literal",
+                    "value": "Scotland"
+                },
+                "adminAreaTypes": {
+                    "type": "literal",
+                    "value": "Q10864048"
+                },
+                "position": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q1362216"
+                },
+                "positionLabel": {
+                    "xml:lang": "en",
+                    "type": "literal",
+                    "value": "First Minister of Scotland"
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Previously this would attempt to create a new Executive object per
position and then fail to sort them. This now groups all positions for a
given executive into the same Executive object.

Closes #85.