### PR TITLE
Handle legislative positions that subclass other positions we return

### DIFF
--- a/lib/commons/builder/queries/legislative.rq.liquid
+++ b/lib/commons/builder/queries/legislative.rq.liquid
@@ -20,7 +20,7 @@ WHERE {
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
   {% lang_options 'name' '?item' %}
-  ?statement ps:P39 ?specific_role .
+  ?statement ps:P39/wdt:P279* ?specific_role .
   {% lang_options 'role' '?role' %}
   OPTIONAL {
     ?role wdt:P279 ?role_superclass .

--- a/lib/commons/builder/queries/legislative_index.rq.liquid
+++ b/lib/commons/builder/queries/legislative_index.rq.liquid
@@ -19,6 +19,15 @@ SELECT DISTINCT ?legislature ?legislatureLabel ?adminArea ?adminAreaLabel ?admin
       VALUES ?legislaturePostSuperType { wd:Q4175034 wd:Q708492 }
       ?legislaturePost wdt:P279+ ?legislaturePostSuperType .
     }
+    # Some legislatures, e.g. Q633872 have multiple 'has part's pointing at
+    # posts, where one subclasses the other. In this case, we want to only
+    # return the parent, and then consider superclasses in the legislative
+    # membership query, so that we don't end up with duplicate legislature
+    # entries in the legislative index.
+    FILTER NOT EXISTS {
+      ?legislature wdt:P527|wdt:P2670 ?legislaturePostOther .
+      ?legislaturePost wdt:P279+ ?legislaturePostOther .
+    }
   }
   OPTIONAL {
     ?legislature wdt:P1342 ?numberOfSeats .


### PR DESCRIPTION
If a house has multiple position 'has part's, and one subclasses
another, then we don't need to include the subclass position in the
legislative index. We can find holders of the subclass position in the
legislative membership query.

This doesn't handle the case of a house having 'has part' positions that
don't subclass each other, which will still cause duplicated entries in
the legislative index, for which we should warn.

No tests as this is just ("just") query changes, which we never satisfactorily test anyway.

Closes #87.