### PR TITLE
Date-aware term condition

### DIFF
--- a/lib/commons/builder/queries/legislative.rq.liquid
+++ b/lib/commons/builder/queries/legislative.rq.liquid
@@ -19,17 +19,17 @@ WHERE {
   }
   ?item wdt:P31 wd:Q5 ;
         p:P39 ?statement .
-  {% lang_options 'name' '?item' %}
   ?statement ps:P39/wdt:P279* ?specific_role .
+  OPTIONAL { ?statement pq:P580 ?start }
+  OPTIONAL { ?statement pq:P582 ?end }
+  {% include 'term_condition' %}
+  {% lang_options 'name' '?item' %}
   {% lang_options 'role' '?role' %}
   OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     {% lang_options 'role_superclass' '?role_superclass' %}
   }
-  OPTIONAL { ?statement pq:P580 ?start }
-  OPTIONAL { ?statement pq:P582 ?end }
-  {% include 'term_condition' %}
   OPTIONAL {
     ?statement pq:P768 ?district.
     {% lang_options 'district_name' '?district' %}

--- a/lib/commons/builder/queries/legislative.rq.liquid
+++ b/lib/commons/builder/queries/legislative.rq.liquid
@@ -27,9 +27,9 @@ WHERE {
     ?role_superclass wdt:P279+ wd:Q4175034
     {% lang_options 'role_superclass' '?role_superclass' %}
   }
-  {% include 'term_condition' %}
   OPTIONAL { ?statement pq:P580 ?start }
   OPTIONAL { ?statement pq:P582 ?end }
+  {% include 'term_condition' %}
   OPTIONAL {
     ?statement pq:P768 ?district.
     {% lang_options 'district_name' '?district' %}

--- a/lib/commons/builder/queries/term_condition.rq.liquid
+++ b/lib/commons/builder/queries/term_condition.rq.liquid
@@ -1,1 +1,17 @@
-{% if term_item_id %}?statement pq:P2937 wd:{{ term_item_id }} .{% endif -%}
+{% if term_item_id -%}
+  OPTIONAL { wd:{{ term_item_id }} wdt:P571|wdt:P580 ?termStart }
+  OPTIONAL { wd:{{ term_item_id }} wdt:P576|wdt:P582 ?termEnd }
+  # A P39 is relevant if it's directly related to the term with a "parliamentary term" qualifier (1), or
+  # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
+  #  * starts before it and either doesn't end, or ends after the term start (3), or
+  #  * starts after the term, and if the term ends, starts before it ends (4)
+  FILTER (
+    (EXISTS { ?statement pq:P2937 wd:{{ term_item_id }} })               # (1)
+    ||
+    (BOUND(?start) && BOUND(?termStart) && (                             # (2)
+      (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)
+      ||
+      (?start > ?termStart && (!BOUND(?termEnd) || ?start < ?termEnd))   # (5)
+    ))
+  )
+{% endif -%}


### PR DESCRIPTION
This extends the term condition subquery to include memberships (P39s) that aren't directly attached to the term with a "parliamentary term" qualifier, but whose start/inception dates overlap the term to some extent.

This helps support legislatures where members are appointed for life but where there is a background parliamentary term system, e.g. in the Canadian Senate and the British House of Lords. Examples:

* https://www.wikidata.org/wiki/Q7416#Q7416$8520BDD5-BC44-456C-AECF-CF841BE78E7C
* https://www.wikidata.org/wiki/Q355188#Q355188$8A400CDA-3F16-4A41-8185-0321CEDEA7C2

See the comment in the term_condition query template for a further explanation of logic encoded in the query.

No tests, as it's a query change against upstream data and we're not good at testing that.