### PR TITLE
Add extra vars to membership query sorts for stability.

### DIFF
--- a/lib/commons/builder/queries/executive.rq.liquid
+++ b/lib/commons/builder/queries/executive.rq.liquid
@@ -44,4 +44,4 @@ WHERE {
     FILTER(?party_end_or_sentinel >= NOW())
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
-} ORDER BY ?item ?role ?district ?start ?end
+} ORDER BY ?item ?role ?district ?start ?end ?role_superclass ?party ?org

--- a/lib/commons/builder/queries/legislative.rq.liquid
+++ b/lib/commons/builder/queries/legislative.rq.liquid
@@ -40,4 +40,4 @@ WHERE {
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
   {% include 'date_condition' %}
-} ORDER BY ?item ?role {% if term_item_id %}?term {% endif %}?start ?end
+} ORDER BY ?item ?role {% if term_item_id %}?term {% endif %}?start ?end ?role_superclass ?party ?org ?district


### PR DESCRIPTION
Adding ?role_superclass resolves unstable sort orders when a ?role has
more than one superclass, and the others are added for completeness.