### PR TITLE
Don't show seat count if there's no position or seat count defined

### DIFF
--- a/lib/commons/builder/legislature.rb
+++ b/lib/commons/builder/legislature.rb
@@ -98,7 +98,7 @@ class Legislature < Branch
   end
 
   def as_popolo_json(wikidata_labels)
-    {
+    output = {
       name: wikidata_labels.labels_for(@house_item_id),
       id: @house_item_id,
       classification: 'branch',
@@ -109,8 +109,9 @@ class Legislature < Branch
         },
       ],
       area_id: area_id,
-      seat_counts: { @position_item_id => @seat_count },
     }
+    output[:seat_counts] = { @position_item_id => @seat_count } if @position_item_id && @seat_count
+    output
   end
 
   def as_json

--- a/test/commons/builder/legislature_test.rb
+++ b/test/commons/builder/legislature_test.rb
@@ -31,4 +31,27 @@ class LegislatureTest < Minitest::Test
     }
     assert_equal expected, legislature.as_popolo_json(wikidata_labels)
   end
+
+  def test_popolo_json_does_not_include_empty_seat_count
+    data = {
+      area_id:           'Q515',
+      house_item_id:     'Q1',
+      position_item_id:  'Q44',
+    }
+    wikidata_labels = wikidata_labels
+    def wikidata_labels.labels_for(_item)
+      { 'lang:en': 'Test legislature' }
+    end
+    legislature = Legislature.new(**data)
+    expected = {
+      name:               { 'lang:en': 'Test legislature' },
+      id:  'Q1',
+      classification:     'branch',
+      identifiers:        [{
+        scheme: 'wikidata', identifier: 'Q1',
+      },],
+      area_id:            'Q515',
+    }
+    assert_equal expected, legislature.as_popolo_json(wikidata_labels)
+  end
 end


### PR DESCRIPTION
This is fixing the problem seen at https://github.com/everypolitician/proto-commons-taiwan/pull/31/commits/ba72cd38098344ea04cb06c88c2ab8d8b84d9264#diff-c423aa3204bf24fec2c4cf4394556ae7R20