### PR TITLE
Sublegislatures edge case

### DIFF
--- a/lib/commons/builder/queries/legislative_index.rq.liquid
+++ b/lib/commons/builder/queries/legislative_index.rq.liquid
@@ -7,7 +7,15 @@ SELECT DISTINCT ?legislature ?legislatureLabel ?adminArea ?adminAreaLabel ?admin
 
   VALUES ?legislatureType { wd:Q11204 wd:Q10553309 }
   ?legislature wdt:P31/wdt:P279* ?legislatureType .
-  FILTER (?legislatureType != wd:Q11204 || NOT EXISTS { ?legislature wdt:P527 ?legislaturePart . ?legislaturePart  wdt:P31/wdt:P279* wd:Q10553309 })
+
+  # Exclude legislatures (but never legislative houses) that "has part"
+  # legislative houses or other legislatures. This happens with UK councils
+  # (see e.g. Q17021809).
+  FILTER (?legislatureType != wd:Q11204 || NOT EXISTS {
+    VALUES ?subLegislatureType { wd:Q10553309 wd:Q11204 }
+    ?legislature wdt:P527 ?legislaturePart .
+    ?legislaturePart  wdt:P31/wdt:P279* ?subLegislatureType .
+  })
 
   # Attempt to find the position for members of the legislature
   OPTIONAL {

--- a/test/commons/builder/legislative_index_test.rb
+++ b/test/commons/builder/legislative_index_test.rb
@@ -97,5 +97,19 @@ module Commons
       Legislature.list(config, options)
       assert_equal(expected, output_stream.string)
     end
+
+    def test_legislature_list_warns_and_excludes_on_missing_position
+      stub_request(:post, 'https://query.wikidata.org/sparql')
+        .to_return(body: open('test/fixtures/missing_position/legislative-index.srj', 'r')).then
+        .to_return(body: open('test/fixtures/missing_position/legislative-index-terms.srj', 'r'))
+      output_stream = StringIO.new
+      expected = <<~EXPECTED
+        WARNING: no position found for the legislature Senate of Canada
+      EXPECTED
+      options = { output_stream: output_stream }
+      legislatures = Legislature.list(config, options)
+      assert_equal(expected, output_stream.string)
+      assert_equal([], legislatures)
+    end
   end
 end

--- a/test/fixtures/missing_position/legislative-index-terms.srj
+++ b/test/fixtures/missing_position/legislative-index-terms.srj
@@ -1,0 +1,21 @@
+{
+    "head": {
+        "vars": [
+            "house",
+            "houseLabel",
+            "legislature",
+            "legislatureLabel",
+            "adminArea",
+            "term",
+            "termLabel",
+            "termStart",
+            "termEnd",
+            "termSpecificPosition",
+            "termSpecificPositionLabel"
+        ]
+    },
+    "results": {
+        "bindings": [
+        ]
+    }
+}

--- a/test/fixtures/missing_position/legislative-index.srj
+++ b/test/fixtures/missing_position/legislative-index.srj
@@ -1,0 +1,60 @@
+{
+    "head": {
+        "vars": [
+            "country",
+            "countryLabel",
+            "body",
+            "bodyLabel",
+            "bodyType",
+            "bodyTypeLabel",
+            "legislature",
+            "legislatureLabel",
+            "legislaturePost",
+            "legislaturePostLabel",
+            "adminArea",
+            "numberOfSeats"
+        ]
+    },
+    "results": {
+        "bindings": [
+            {
+                "body": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q16"
+                },
+                "bodyLabel": {
+                    "xml:lang": "en",
+                    "type": "literal",
+                    "value": "Canada"
+                },
+                "bodyType": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q6256"
+                },
+                "bodyTypeLabel": {
+                    "xml:lang": "en",
+                    "type": "literal",
+                    "value": "country"
+                },
+                "legislature": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q841180"
+                },
+                "legislatureLabel": {
+                    "xml:lang": "en",
+                    "type": "literal",
+                    "value": "Senate of Canada"
+                },
+                "adminArea": {
+                    "type": "uri",
+                    "value": "http://www.wikidata.org/entity/Q16"
+                },
+                "numberOfSeats": {
+                    "datatype": "http://www.w3.org/2001/XMLSchema#decimal",
+                    "type": "literal",
+                    "value": "87"
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Two related changes:

* Warn on and don't include legislatures without positions
* Ignore legislatures that have parts that are also legislatures

This means we'll no longer have `"position_item_id": null` in our legislative index, which causes trouble down the line, and we'll be warned of legislatures without positions. We also now exclude legislatures that have legislatures within them — see second commit message for more detail.