### PR TITLE
Only integrity-check WIKIDATA in boundaries/build CSV files

### DIFF
--- a/integrity-config.yml
+++ b/integrity-config.yml
@@ -1,5 +1,5 @@
 WikidataIdentifiers:
-  AppliesTo: 'boundaries/**/*.csv'
+  AppliesTo: 'boundaries/build/*/*.csv'
   column_name: 'WIKIDATA'
   column_case: 'fixed'
 AreaPositionsKnown:


### PR DESCRIPTION
Previously, this checked every CSV under boundaries, which included
those in boundaries/source/, not all of which are guaranteed to be
UTF-8. Any non-UTF-8 source CSV therefore caused the integrity checks to
fail with an exception when parsed.

This does mean that repositories with boundaries not in
boundaries/build/ don't have their CSV files checked, but those are
becoming increasingly rare, and can/should be moved to use
boundaries/build.