### PR TITLE
Ignore dissolved legislative positions

### DIFF
--- a/lib/commons/builder/queries/legislative_index.rq.liquid
+++ b/lib/commons/builder/queries/legislative_index.rq.liquid
@@ -36,6 +36,7 @@ SELECT DISTINCT ?legislature ?legislatureLabel ?adminArea ?adminAreaLabel ?admin
       ?legislature wdt:P527|wdt:P2670 ?legislaturePostOther .
       ?legislaturePost wdt:P279+ ?legislaturePostOther .
     }
+    FILTER NOT EXISTS { ?legislaturePost wdt:P576 ?legislaturePostEnd . FILTER (?legislaturePostEnd < NOW()) }
   }
   OPTIONAL {
     ?legislature wdt:P1342 ?numberOfSeats .


### PR DESCRIPTION
Queries previously picked up dissolved positions, e.g. https://www.wikidata.org/wiki/Q56876060, which makes it slightly non-deterministic as to which position is used for the files generated on disk.

No tests because purely a query change which we can't test effectively (as before).