### PR TITLE
Ignore dissolved positions in executive index and position-data

### DIFF
--- a/lib/commons/builder/queries/executive_index.rq.liquid
+++ b/lib/commons/builder/queries/executive_index.rq.liquid
@@ -22,6 +22,8 @@ SELECT DISTINCT ?executive ?executiveLabel ?adminArea ?adminAreaLabel ?adminArea
       FILTER NOT EXISTS { ?executive wdt:P31/wdt:P279* wd:Q6528244 }
       # Exclude executives which aren't direct parents of the position
       FILTER NOT EXISTS { ?position wdt:P361 ?other . ?other wdt:P361+ ?executive }
+      # Filter positions that have been dissolved
+      FILTER NOT EXISTS { ?position wdt:P576 ?positionEnd . FILTER (?positionEnd < NOW()) }
     }
   }
 

--- a/lib/commons/builder/queries/information_from_positions.rq.liquid
+++ b/lib/commons/builder/queries/information_from_positions.rq.liquid
@@ -9,11 +9,12 @@ WHERE {
   {
     {% include 'select_admin_areas_for_country' %}
   }
-  {% lang_options 'position_name' '?position' %}
-  ?body wdt:P527|wdt:P2670|wdt:P2388 ?position .
-  MINUS { ?body wdt:P576|wdt:P582 ?bodyEnd . FILTER(?bodyEnd < NOW()) }
-  {% lang_options 'body' '?body' %}
   ?body wdt:P1001 ?adminArea .
+  ?body wdt:P527|wdt:P2670|wdt:P2388 ?position .
+  {% lang_options 'body' '?body' %}
+  {% lang_options 'position_name' '?position' %}
+  MINUS { ?body wdt:P576|wdt:P582 ?bodyEnd . FILTER(?bodyEnd < NOW()) }
+  MINUS { ?position wdt:P576|wdt:P582 ?positionEnd . FILTER(?positionEnd < NOW()) }
   {% lang_options 'admin_area' '?adminArea' %}
   OPTIONAL {
     # If this position appears to be legislative (it's an subclass* of 'legislator')


### PR DESCRIPTION
This extends previous work with legislative positions to also ignore dissolved positions in executive index and position data queries

Also includes some clause reordering for clarity.

No tests as it's just a query change and we struggle to test those.

Follows on from #110, which only covered the legislative index.