### PR TITLE
Always expose term dates, even when there is an item ID.

### DIFF
--- a/lib/commons/builder/legislative_term.rb
+++ b/lib/commons/builder/legislative_term.rb
@@ -47,12 +47,9 @@ class LegislativeTerm
     result = {}
     result[:comment] = @comment if @comment
     result[:position_item_id] = @position_item_id if @position_item_id
-    if @term_item_id
-      result[:term_item_id] = @term_item_id if @term_item_id
-    else
-      result[:start_date] = @start_date
-      result[:end_date] = @end_date
-    end
+    result[:term_item_id] = @term_item_id if @term_item_id
+    result[:start_date] = @start_date if @start_date
+    result[:end_date] = @end_date if @end_date
     result
   end
 end

--- a/test/commons/builder/legislative_term_test.rb
+++ b/test/commons/builder/legislative_term_test.rb
@@ -23,4 +23,23 @@ class LegislativeTermTest < Minitest::Test
     assert_match(/\WBIND\(wd:Q1234 as \?role\)\W/, query)
     assert_match(/\WBIND\(wd:Q5678 as \?specific_role\)\W/, query)
   end
+
+  def test_term_as_json
+    full_data = { comment: 'Test term',
+                  term_item_id: 'Q3',
+                  start_date: '2001-02-03',
+                  end_date: '2002-03-04', }.to_a
+    # Ensure that all combinations of term data are serialized as expected.
+    (1..4).flat_map { |n| full_data.combination(n).to_a }.map(&:to_h).each do |data|
+      exception_expected = !data[:term_item_id] && !(data[:start_date] && data[:end_date])
+      begin
+        term = LegislativeTerm.new legislature: nil, **data
+      rescue
+        assert_equal true, exception_expected
+      else
+        assert_equal false, exception_expected
+        assert_equal data, term.as_json
+      end
+    end
+  end
 end


### PR DESCRIPTION
Closes #98.