### PR TITLE
Only filter out replaced terms if they don't have end dates.

### DIFF
--- a/lib/commons/builder/queries/legislative_index_terms.rq.liquid
+++ b/lib/commons/builder/queries/legislative_index_terms.rq.liquid
@@ -26,7 +26,10 @@ WHERE {
                                    pq:P2937 ?term ] .
   }
 
+  # Only include terms without end dates or whose end dates are in the future
   FILTER (!BOUND(?termEnd) || ?termEnd > NOW())
-  FILTER (!BOUND(?termReplacedBy))
+  # Only include terms which haven't been replaced unless they have end dates
+  # (and so by implication, as per above, have end dates in the future)
+  FILTER (!BOUND(?termReplacedBy) || BOUND(?termEnd))
   {% include 'label_service' %}
 } ORDER BY ?termStart ?term


### PR DESCRIPTION
This means we no longer exclude current terms if someone has created the next (future) term in Wikidata and added a "followed by" statement to the current term.

See comments in the code for an explanation of the logic of the new behaviour.

An example of this in use with a cut-down query for Brazil's Senate shows both the current and future terms: http://tinyurl.com/y85aky87