### PR TITLE
Add term ID to memberships if explicitly linked.

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -79,7 +79,7 @@ boundary_position_ids = boundary_data.popolo_areas.map { |a| a[:associated_wikid
       next unless actions.include?('build')
       membership_rows = wikidata_results_parser.parse(query.last_saved_results)
 
-      membership_data = MembershipData.new(membership_rows, wikidata_labels, political_entity_kind)
+      membership_data = MembershipData.new(membership_rows, wikidata_labels, political_entity_kind, term)
 
       # We should have all the relevant areas from the boundary data...
       related_positions = branch.positions_item_ids

--- a/lib/commons/builder/membership_data.rb
+++ b/lib/commons/builder/membership_data.rb
@@ -3,13 +3,14 @@
 # This class handles the data we have from Wikidata about memberships
 
 class MembershipData
-  attr_reader :membership_rows, :wikidata_labels, :political_entity_kind
+  attr_reader :membership_rows, :wikidata_labels, :political_entity_kind, :term
 
-  def initialize(membership_rows, wikidata_labels, political_entity_kind, options = {})
+  def initialize(membership_rows, wikidata_labels, political_entity_kind, term, options = {})
     @membership_rows = membership_rows
     @wikidata_labels = wikidata_labels
     @political_entity_kind = political_entity_kind
     @output_stream = options.fetch(:output_stream) { $stdout }
+    @term = term
   end
 
   def persons
@@ -60,6 +61,7 @@ class MembershipData
         role_superclass: membership[:role_superclass] && membership.name_object('role_superclass'),
         role_code: membership[:role].value,
         role: membership.name_object('role'),
+        term_id: (membership[:linkedToTerm]&.value ? term.term_item_id : nil),
       }.reject { |_, v| v.to_s.empty? }
       # The id here is the statement UUID, so you would have thought
       # that was enough to predictably order these, However, the

--- a/lib/commons/builder/queries/legislative.rq.liquid
+++ b/lib/commons/builder/queries/legislative.rq.liquid
@@ -6,6 +6,7 @@ SELECT ?statement
        ?role_superclass {% lang_select 'role_superclass' %}
        ?start ?end ?facebook
        ?org {% lang_select 'org' %} ?org_jurisdiction ?org_seat_count
+       ?linkedToTerm
 WHERE {
   BIND(wd:{{ position_item_id }} as ?role) .
   BIND(wd:{{ specific_position_item_id }} as ?specific_role) .

--- a/lib/commons/builder/queries/term_condition.rq.liquid
+++ b/lib/commons/builder/queries/term_condition.rq.liquid
@@ -5,8 +5,9 @@
   # it overlaps it. In the latter case, the P39 and term must each have a start date (2), and either
   #  * starts before it and either doesn't end, or ends after the term start (3), or
   #  * starts after the term, and if the term ends, starts before it ends (4)
+  BIND ((EXISTS { ?statement pq:P2937 wd:{{ term_item_id }} }) AS ?linkedToTerm)
   FILTER (
-    (EXISTS { ?statement pq:P2937 wd:{{ term_item_id }} })               # (1)
+    ?linkedToTerm                                                        # (1)
     ||
     (BOUND(?start) && BOUND(?termStart) && (                             # (2)
       (?start <= ?termStart && (!BOUND(?end) || ?end > ?termStart))      # (4)

--- a/lib/commons/builder/wikidata_results.rb
+++ b/lib/commons/builder/wikidata_results.rb
@@ -11,6 +11,7 @@ class WikidataCell
   def value
     return raw_value.split('/').last if wikidata_item?
     return raw_value.to_s[0...10] if date?
+    return raw_value == 'true' if boolean?
     raw_value
   end
 
@@ -24,6 +25,10 @@ class WikidataCell
 
   def date?
     datatype == 'http://www.w3.org/2001/XMLSchema#dateTime'
+  end
+
+  def boolean?
+    datatype == 'http://www.w3.org/2001/XMLSchema#boolean'
   end
 
   def raw_value

--- a/test/commons/builder/membership_data_test.rb
+++ b/test/commons/builder/membership_data_test.rb
@@ -19,40 +19,44 @@ module Commons
       ['en', 'zh-tw', 'zh']
     end
 
+    def term
+      CurrentExecutive.new executive: nil
+    end
+
     def wikidata_labels
       Minitest::Mock.new
     end
 
     def test_can_access_membership_rows
       membership_rows = []
-      membership_data = MembershipData.new(membership_rows, wikidata_labels, 'executive')
+      membership_data = MembershipData.new(membership_rows, wikidata_labels, 'executive', term)
       assert_equal(membership_rows, membership_data.membership_rows)
     end
 
     def test_persons_produces_expected_json
       membership_rows = membership_rows('test/fixtures/membership_data/results.json')
-      membership_data = MembershipData.new(membership_rows, wikidata_labels, 'executive')
+      membership_data = MembershipData.new(membership_rows, wikidata_labels, 'executive', term)
       expected_data = json_data('test/fixtures/membership_data/expected.json')
       assert_equal(expected_data[:persons], membership_data.persons)
     end
 
     def test_memberships_produces_expected_json
       membership_rows = membership_rows('test/fixtures/membership_data/results.json')
-      membership_data = MembershipData.new(membership_rows, wikidata_labels, 'executive')
+      membership_data = MembershipData.new(membership_rows, wikidata_labels, 'executive', term)
       expected_data = json_data('test/fixtures/membership_data/expected.json')
       assert_equal(expected_data[:memberships], membership_data.memberships)
     end
 
     def test_organizations_produces_expected_json
       membership_rows = membership_rows('test/fixtures/membership_data/results.json')
-      membership_data = MembershipData.new(membership_rows, wikidata_labels, 'executive')
+      membership_data = MembershipData.new(membership_rows, wikidata_labels, 'executive', term)
       expected_data = json_data('test/fixtures/membership_data/expected.json')
       assert_equal(expected_data[:organizations], membership_data.organizations)
     end
 
     def test_persons_assigns_multiple_links
       membership_rows = membership_rows('test/fixtures/two_links/results.json')
-      membership_data = MembershipData.new(membership_rows, wikidata_labels, 'executive')
+      membership_data = MembershipData.new(membership_rows, wikidata_labels, 'executive', term)
       expected_data = json_data('test/fixtures/two_links/expected.json')
       assert_equal(expected_data[:organizations], membership_data.organizations)
     end

--- a/test/commons/builder/wikidata_results_test.rb
+++ b/test/commons/builder/wikidata_results_test.rb
@@ -28,16 +28,16 @@ module Commons
     end
 
     def test_extract_boolean
-      data = { true: { type: 'literal',
-                       value: 'true',
-                       datatype: 'http://www.w3.org/2001/XMLSchema#boolean'},
-               false: { type: 'literal',
-                       value: 'false',
-                       datatype: 'http://www.w3.org/2001/XMLSchema#boolean'}, }
+      data = { true_binding: { type: 'literal',
+                               value: 'true',
+                               datatype: 'http://www.w3.org/2001/XMLSchema#boolean', },
+               false_binding: { type: 'literal',
+                                value: 'false',
+                                datatype: 'http://www.w3.org/2001/XMLSchema#boolean', }, }
       languages = ['en']
       row = WikidataRow.new(data, languages)
-      assert_equal(true, row[:true].value)
-      assert_equal(false, row[:false].value)
+      assert_equal(true, row[:true_binding].value)
+      assert_equal(false, row[:false_binding].value)
     end
   end
 end

--- a/test/commons/builder/wikidata_results_test.rb
+++ b/test/commons/builder/wikidata_results_test.rb
@@ -26,5 +26,18 @@ module Commons
       expected = { "lang:en": 'Kuomintang', "lang:zh-tw": '中國國民黨' }
       assert_equal(expected, row.name_object('party_name'))
     end
+
+    def test_extract_boolean
+      data = { true: { type: 'literal',
+                       value: 'true',
+                       datatype: 'http://www.w3.org/2001/XMLSchema#boolean'},
+               false: { type: 'literal',
+                       value: 'false',
+                       datatype: 'http://www.w3.org/2001/XMLSchema#boolean'}, }
+      languages = ['en']
+      row = WikidataRow.new(data, languages)
+      assert_equal(true, row[:true].value)
+      assert_equal(false, row[:false].value)
+    end
   end
 end


### PR DESCRIPTION
No proper tests yet.