### PR TITLE
Fix the null parent_id check

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -115,7 +115,7 @@ boundary_position_ids = boundary_data.popolo_areas.map { |a| a[:associated_wikid
       # Check that none of these have a null person_id - we should only
       # allow that for the whole-country area.
       areas_with_bad_parents = areas.select do |area|
-        area[:parent_id].nil? && !area[:id] == config.country_wikidata_id
+        area[:parent_id].nil? && area[:id] != config.country_wikidata_id
       end
       unless areas_with_bad_parents.empty?
         areas_with_bad_parents.each do |area|


### PR DESCRIPTION
`!str == otherStr` will always be false, regardless of whether or not `str` and `otherStr` are equal, as `!` binds more tightly than `==`, turning the LHS into `false`.

This bug explains why this warning was never effective.

No tests as we (wrongly) don't test `bin/build`.

Resolves #119.